### PR TITLE
Fix game list param handling

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -14,7 +14,7 @@ class GameController < ApplicationController
 
   def list
     store_location
-    @type = params[:type].to_sym || :scheduled
+    @type = params[:type]&.to_sym || :scheduled
     @games = Game
     @categories = Category.all
     @category = params[:category] || 1


### PR DESCRIPTION
## Summary
- fix `@type` extraction when listing games by using safe `to_sym`

## Testing
- `bundle exec rails test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d33fc6c48330980d8bad2d443cb5