### PR TITLE
Fix typo in access_denied message

### DIFF
--- a/lib/authenticated_system.rb
+++ b/lib/authenticated_system.rb
@@ -70,7 +70,7 @@ module AuthenticatedSystem
         accepts.xml do
           headers["Status"]           = "Unauthorized"
           headers["WWW-Authenticate"] = %(Basic realm="Web Password")
-          render :text => "Could't authenticate you", :status => '401 Unauthorized'
+          render :text => "Couldn't authenticate you", :status => '401 Unauthorized'
         end
       end
       false


### PR DESCRIPTION
## Summary
- fix message when access is denied

## Testing
- `bundle exec rake test` *(fails: capistrano/rbenv not checked out)*

------
https://chatgpt.com/codex/tasks/task_e_6877d1e75d188330850e7f99b47a4af7