### PR TITLE
Track and graph historical team odds evolution

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -221,6 +221,16 @@ class ChampionshipController < ApplicationController
     end
     chart[:data] << line
 
+    team_group = group.team_groups.find_by(team_id: team.id)
+    historical_odds = team_group.historical_odds.order(:measure_date)
+    chart[:odds_evolution] = group.zones.map do |zone|
+      {
+        label: zone["name"],
+        color: zone["color"],
+        data: historical_odds.map { |ho| [ho.measure_date.to_time.to_i * 1000, (ho.calculate_odds(zone["position"]) || 0) * 100] }
+      }
+    end
+
     return chart.to_json, team_table
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -29,6 +29,7 @@ class Group < ApplicationRecord
       team_groups.each do |t|
         t.odds = calculated_odds["team_odds"][t.team_id.to_s]['Pos']
         t.save
+        HistoricalOdds.find_or_initialize_by(team_group_id: t.id, measure_date: Date.today).update(odds: t.odds)
       end
       now = Time.zone.now.to_s.chop.chop.chop.chop
       importance = calculated_odds["game_importance"]

--- a/app/models/historical_odds.rb
+++ b/app/models/historical_odds.rb
@@ -1,0 +1,13 @@
+class HistoricalOdds < ApplicationRecord
+  serialize :odds, type: Array
+  belongs_to :team_group
+
+  validates :team_group_id, presence: true
+  validates :measure_date, presence: true
+  validates :measure_date, uniqueness: { scope: :team_group_id }
+
+  def calculate_odds(positions)
+    return nil if not odds or positions.nil?
+    positions.map{|p| odds[p-1].to_f}.sum
+  end
+end

--- a/app/models/team_group.rb
+++ b/app/models/team_group.rb
@@ -2,6 +2,7 @@ class TeamGroup < ApplicationRecord
   serialize :odds
   belongs_to :group, :touch => true
   belongs_to :team
+  has_many :historical_odds, :dependent => :delete_all
   validates_numericality_of :add_sub, :only_integer => true
   validates_numericality_of :bias, :only_integer => true
   validates_uniqueness_of :team_id, :scope => :group_id

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -475,6 +475,13 @@ $(document).ready(function() {
           line-height: 1.2em;"></div>
       </div>
       <div id="legend<%=idx%>"></div>
+      <div style="margin-top: 20px;">
+        <h3><%= _("Odds Evolution") %></h3>
+        <div id="odds_evolution<%=idx%>" style="width: 550px;
+          height: 300px;
+          font-size: 14px;
+          line-height: 1.2em;"></div>
+      </div>
 <style>
 #legend {
   width: 100% !important;
@@ -507,6 +514,55 @@ $(document).ready(function() {
     };
 
     graphDiv.plot(data[<%=idx%>].data, options);
+
+    var oddsEvolutionDiv = $("#odds_evolution<%=idx%>");
+    var oddsData = data[<%=idx%>]["odds_evolution"];
+    var oddsOptions = {
+      xaxis: {
+        mode: "time",
+        timeformat: "%d/%m",
+      },
+      yaxis: {
+        min: 0,
+        max: 100,
+        ticks: 10,
+        tickFormatter: function(v) { return v + "%"; }
+      },
+      series: {
+        lines: { show: true },
+        points: { show: true }
+      },
+      grid: {
+        hoverable: true,
+        backgroundColor: "#FFFFFF",
+      },
+    };
+    if (oddsData && oddsData.some(d => d.data.length > 0)) {
+      $.plot(oddsEvolutionDiv, oddsData, oddsOptions);
+      $("<div id='odds_evolution_tooltip<%=idx%>'></div>").css({
+        position: "absolute",
+        display: "none",
+        border: "1px solid #fdd",
+        padding: "2px",
+        "background-color": "#fee",
+        opacity: 0.80,
+      }).appendTo("body");
+
+      oddsEvolutionDiv.bind("plothover", function (event, pos, item) {
+        if (item) {
+          var date = new Date(item.datapoint[0]);
+          var dateStr = date.getDate() + "/" + (date.getMonth() + 1);
+          var val = item.datapoint[1].toFixed(2) + "%";
+          $("#odds_evolution_tooltip<%=idx%>").html(item.series.label + " (" + dateStr + "): " + val)
+              .css({top: pos.pageY+5, left: pos.pageX+5})
+              .fadeIn(200);
+        } else {
+          $("#odds_evolution_tooltip<%=idx%>").hide();
+        }
+      });
+    } else {
+      oddsEvolutionDiv.parent().hide();
+    }
 
     $("<div id='tooltip'></div>").css({
       position: "absolute",

--- a/db/migrate/20260216061733_create_historical_odds.rb
+++ b/db/migrate/20260216061733_create_historical_odds.rb
@@ -1,0 +1,20 @@
+class CreateHistoricalOdds < ActiveRecord::Migration[7.2]
+  def up
+    create_table :historical_odds do |t|
+      t.references :team_group, null: false, foreign_key: true
+      t.date :measure_date, null: false
+      t.text :odds
+      t.timestamps
+    end
+    add_index :historical_odds, [:team_group_id, :measure_date], unique: true
+
+    # Backfill current odds
+    TeamGroup.where.not(odds: nil).each do |tg|
+      HistoricalOdds.create(team_group_id: tg.id, measure_date: Date.today, odds: tg.odds)
+    end
+  end
+
+  def down
+    drop_table :historical_odds
+  end
+end

--- a/test/unit/historical_odds_test.rb
+++ b/test/unit/historical_odds_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class HistoricalOddsTest < ActiveSupport::TestCase
+  test "calculate_odds returns sum of probabilities for given positions" do
+    ho = HistoricalOdds.new(odds: [0.1, 0.2, 0.3, 0.4])
+    assert_equal 0.3, ho.calculate_odds([1, 2])
+    assert_equal 0.7, ho.calculate_odds([3, 4])
+    assert_equal 0.6, ho.calculate_odds([1, 2, 3])
+  end
+
+  test "calculate_odds returns nil if odds are missing" do
+    ho = HistoricalOdds.new(odds: nil)
+    assert_nil ho.calculate_odds([1, 2])
+  end
+
+  test "calculate_odds returns 0 if no positions match" do
+    ho = HistoricalOdds.new(odds: [0.1, 0.2])
+    assert_equal 0, ho.calculate_odds([])
+  end
+end


### PR DESCRIPTION
This feature allows tracking the evolution of a team's odds for various classification zones over time. 

Key changes:
1.  **Database**: Added `historical_odds` table to store serialized positional probabilities with a daily unique constraint per team group.
2.  **Model**: Introduced `HistoricalOdds` model with a `calculate_odds` method that sums probabilities for a given set of positions. This allows dynamic recalculation if zone definitions change.
3.  **Recording**: Modified `Group#odds` to automatically save the current snapshot to the historical table.
4.  **Backend**: Updated `ChampionshipController#generate_team_json` to group historical data by the current classification zones defined for the group.
5.  **Frontend**: Added a new time-series line graph on the team page (within each phase tab) showing the evolution of probabilities for each zone.

The implementation ensures that even if classification zones are modified later, the historical graph will reflect the probability of those new definitions over time, as requested.

---
*PR created automatically by Jules for task [3113703602533582466](https://jules.google.com/task/3113703602533582466) started by @galo2099*