### PR TITLE
Limit odds backfill writes to odds history snapshots only

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -16,7 +16,7 @@ class Group < ApplicationRecord
 
   NUM_ITER = 10000
 
-  def odds(games_json: nil, snapshot_time: Time.zone.now, persist_game_importance: true)
+  def odds(games_json: nil, snapshot_time: Time.zone.now, persist_game_importance: true, persist_team_odds: true, persist_group_progress: true)
     req = Net::HTTP::Post.new("/odds", {'Content-Type' =>'application/json'})
     games_json ||= games.includes(:home, :away).as_json(
       methods: [:home_power, :away_power],
@@ -32,7 +32,7 @@ class Group < ApplicationRecord
     ActiveRecord::Base.transaction do
       team_groups.each do |t|
         t.odds = calculated_odds["team_odds"][t.team_id.to_s]['Pos']
-        t.save
+        t.save if persist_team_odds
         t.record_odds_snapshot!(snapshot_time)
       end
       if persist_game_importance
@@ -81,8 +81,10 @@ class Group < ApplicationRecord
         ActiveRecord::Base.connection.execute(sql)
       end
       end
-      self.odds_progress = 100
-      self.save
+      if persist_group_progress
+        self.odds_progress = 100
+        self.save
+      end
     end
   end
 

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -112,7 +112,9 @@ class OddsHistoryBackfillService
         group.odds(
           games_json: games_json_for_day,
           snapshot_time: day.end_of_day,
-          persist_game_importance: false
+          persist_game_importance: false,
+          persist_team_odds: false,
+          persist_group_progress: false
         )
 
         puts "   [#{idx + 1}/#{game_days.size}] #{day}"

--- a/test/unit/group_test.rb
+++ b/test/unit/group_test.rb
@@ -65,4 +65,61 @@ class GroupTest < ActiveSupport::TestCase
     assert_kind_of Array, retrieved_group.zones, "Zones attribute should be an Array"
   end
 
+
+  test 'odds backfill mode only writes odds history' do
+    category = Category.create!(name: 'Backfill Category')
+    championship = Championship.create!(
+      name: 'Backfill Championship',
+      region: :national,
+      category_id: category.id,
+      begin: Date.today,
+      end: Date.today + 30.days,
+      point_win: 3,
+      point_draw: 1,
+      point_loss: 0
+    )
+    phase = Phase.create!(
+      name: 'Backfill Phase',
+      championship: championship,
+      order_by: 1,
+      sort: 'pt,gd'
+    )
+    group = Group.create!(name: 'Backfill Group', phase: phase)
+    home = Team.create!(name: 'Backfill FC', country: 'Brazil')
+    away = Team.create!(name: 'Snapshot United', country: 'Brazil')
+    tg_home = TeamGroup.create!(group: group, team: home, add_sub: 0, bias: 0)
+    tg_away = TeamGroup.create!(group: group, team: away, add_sub: 0, bias: 0)
+
+    response = Struct.new(:body).new({
+      'team_odds' => {
+        home.id.to_s => { 'Pos' => [0.65, 0.35] },
+        away.id.to_s => { 'Pos' => [0.35, 0.65] }
+      },
+      'game_importance' => {}
+    }.to_json)
+
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) { |_req| response }
+    fake_client = Object.new
+    fake_client.define_singleton_method(:start) { |&block| block.call(fake_http) }
+
+    group_progress_before = group.odds_progress
+
+    assert_difference 'TeamGroupOddsHistory.count', +2 do
+      Net::HTTP.stub(:new, fake_client) do
+        group.odds(
+          games_json: [],
+          snapshot_time: Time.zone.parse('2024-06-01 10:00:00'),
+          persist_game_importance: false,
+          persist_team_odds: false,
+          persist_group_progress: false
+        )
+      end
+    end
+
+    assert_nil tg_home.reload.odds
+    assert_nil tg_away.reload.odds
+    assert_equal group_progress_before, group.reload.odds_progress
+  end
+
 end


### PR DESCRIPTION
### Motivation
- Backfilling historical odds should only create odds history snapshots and must not mutate current team or group state (team odds, game importance, or group progress).

### Description
- Add two optional flags to `Group#odds`: `persist_team_odds` and `persist_group_progress`, defaulting to `true`, and use them to skip saving `team_groups.odds` and `group.odds_progress` when disabled.
- Update `OddsHistoryBackfillService` to call `group.odds` with `persist_game_importance: false`, `persist_team_odds: false`, and `persist_group_progress: false` so backfill runs in history-only mode.
- Add a unit test `test 'odds backfill mode only writes odds history'` in `test/unit/group_test.rb` to assert that only `TeamGroupOddsHistory` rows are created and that team/group fields remain unchanged when the history-only flags are used.

### Testing
- `ruby -c` syntax checks for `app/models/group.rb`, `app/services/odds_history_backfill_service.rb`, and `test/unit/group_test.rb` all passed.
- The new unit test file was added and is syntactically valid (`ruby -c test/unit/group_test.rb` passed).
- Running the test under Bundler with `bundle exec ruby -Itest test/unit/group_test.rb` failed in this environment because a git-sourced dependency (`userstamp`) is not checked out and `bundle install` must be run first, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936ceabf048330a2de47308d159958)