### PR TITLE
Odds history graph layout

### DIFF
--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -609,12 +609,12 @@ $(document).ready(function() {
 
       function renderOddsHistorySeries() {
         var oddsHistoryYAxisTicks = [
-          [0, "0.0"],
-          [20, "0.2"],
-          [40, "0.4"],
-          [60, "0.6"],
-          [80, "0.8"],
-          [100, "1.0"],
+          [0, ""],
+          [20, ""],
+          [40, ""],
+          [60, ""],
+          [80, ""],
+          [100, ""],
         ];
 
         var seriesToRender = allOddsHistorySeries

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -569,12 +569,12 @@ $(document).ready(function() {
 
       function renderOddsHistorySeries() {
         var oddsHistoryYAxisTicks = [
-          [0.0, "0.0"],
-          [0.2, "0.2"],
-          [0.4, "0.4"],
-          [0.6, "0.6"],
-          [0.8, "0.8"],
-          [1.0, "1.0"],
+          [0, "0.0"],
+          [20, "0.2"],
+          [40, "0.4"],
+          [60, "0.6"],
+          [80, "0.8"],
+          [100, "1.0"],
         ];
 
         var seriesToRender = allOddsHistorySeries
@@ -601,8 +601,8 @@ $(document).ready(function() {
               return xTickLabels[Math.round(value)] || "";
             },
           },
-          yaxis: { min: 0, max: 1, autoScale: false, reserveSpace: true, tickDecimals: 1, ticks: oddsHistoryYAxisTicks },
-          yaxes: [{ min: 0, max: 1, autoScale: false, reserveSpace: true, tickDecimals: 1, ticks: oddsHistoryYAxisTicks }],
+          yaxis: { min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks },
+          yaxes: [{ min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks }],
           series: {
             stack: true,
             lines: { show: true, fill: 0.85, lineWidth: 1 },

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -524,19 +524,15 @@ $(document).ready(function() {
       var xMin = null;
       var xMax = null;
       var xValueMap = {};
-      var xTickLabels = {};
       var xAxisTicks = [];
       var timestampMetaMap = {};
       var oddsHistoryLocale = "<%= I18n.locale %>".toString().replace(/_/g, "-");
-      var compactDateFormatter = null;
       var fullDateFormatter = null;
 
       if (window.Intl && Intl.DateTimeFormat) {
         try {
-          compactDateFormatter = new Intl.DateTimeFormat(oddsHistoryLocale, { day: "2-digit", month: "2-digit" });
           fullDateFormatter = new Intl.DateTimeFormat(oddsHistoryLocale, { year: "numeric", month: "2-digit", day: "2-digit" });
         } catch (error) {
-          compactDateFormatter = null;
           fullDateFormatter = null;
         }
       }
@@ -577,7 +573,6 @@ $(document).ready(function() {
 
         uniqueSortedTimestamps.forEach(function(timestamp, index) {
           xValueMap[timestamp] = index;
-          xTickLabels[index] = formatOddsHistoryDate(timestampMetaMap[timestamp], compactDateFormatter, false);
         });
 
         xMin = 0;
@@ -587,10 +582,10 @@ $(document).ready(function() {
         var denominator = Math.max(maxXAxisLabelCount - 1, 1);
         var tickStep = Math.max(1, Math.ceil((totalPoints - 1) / denominator));
         for (var tickPosition = 0; tickPosition < totalPoints; tickPosition += tickStep) {
-          xAxisTicks.push([tickPosition, xTickLabels[tickPosition] || ""]);
+          xAxisTicks.push([tickPosition, ""]);
         }
         if (xAxisTicks.length === 0 || xAxisTicks[xAxisTicks.length - 1][0] !== totalPoints - 1) {
-          xAxisTicks.push([totalPoints - 1, xTickLabels[totalPoints - 1] || ""]);
+          xAxisTicks.push([totalPoints - 1, ""]);
         }
       }
 

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -525,7 +525,42 @@ $(document).ready(function() {
       var xMax = null;
       var xValueMap = {};
       var xTickLabels = {};
+      var xAxisTicks = [];
       var timestampMetaMap = {};
+      var oddsHistoryLocale = "<%= I18n.locale %>".toString().replace(/_/g, "-");
+      var compactDateFormatter = null;
+      var fullDateFormatter = null;
+
+      if (window.Intl && Intl.DateTimeFormat) {
+        try {
+          compactDateFormatter = new Intl.DateTimeFormat(oddsHistoryLocale, { day: "2-digit", month: "2-digit" });
+          fullDateFormatter = new Intl.DateTimeFormat(oddsHistoryLocale, { year: "numeric", month: "2-digit", day: "2-digit" });
+        } catch (error) {
+          compactDateFormatter = null;
+          fullDateFormatter = null;
+        }
+      }
+
+      function parseOddsHistoryDate(value) {
+        if (!value) { return null; }
+        var parts = value.toString().split("-");
+        if (parts.length !== 3) { return null; }
+        var year = parseInt(parts[0], 10);
+        var month = parseInt(parts[1], 10) - 1;
+        var day = parseInt(parts[2], 10);
+        if (isNaN(year) || isNaN(month) || isNaN(day)) { return null; }
+        return new Date(year, month, day);
+      }
+
+      function formatOddsHistoryDate(value, formatter, includeYear) {
+        if (!value) { return ""; }
+        var parsedDate = parseOddsHistoryDate(value);
+        if (!parsedDate) { return value; }
+        if (formatter) { return formatter.format(parsedDate); }
+        var day = parsedDate.getDate() < 10 ? "0" + parsedDate.getDate() : parsedDate.getDate().toString();
+        var month = (parsedDate.getMonth() + 1) < 10 ? "0" + (parsedDate.getMonth() + 1) : (parsedDate.getMonth() + 1).toString();
+        return includeYear ? day + "/" + month + "/" + parsedDate.getFullYear() : day + "/" + month;
+      }
       oddsHistory.series.forEach(function(series) {
         (series.data || []).forEach(function(point, pointIndex) {
           var pointMeta = (series.point_meta || [])[pointIndex] || {};
@@ -542,11 +577,21 @@ $(document).ready(function() {
 
         uniqueSortedTimestamps.forEach(function(timestamp, index) {
           xValueMap[timestamp] = index;
-          xTickLabels[index] = timestampMetaMap[timestamp] || "";
+          xTickLabels[index] = formatOddsHistoryDate(timestampMetaMap[timestamp], compactDateFormatter, false);
         });
 
         xMin = 0;
         xMax = Math.max(uniqueSortedTimestamps.length - 1, 0);
+        var maxXAxisLabelCount = 6;
+        var totalPoints = uniqueSortedTimestamps.length;
+        var denominator = Math.max(maxXAxisLabelCount - 1, 1);
+        var tickStep = Math.max(1, Math.ceil((totalPoints - 1) / denominator));
+        for (var tickPosition = 0; tickPosition < totalPoints; tickPosition += tickStep) {
+          xAxisTicks.push([tickPosition, xTickLabels[tickPosition] || ""]);
+        }
+        if (xAxisTicks.length === 0 || xAxisTicks[xAxisTicks.length - 1][0] !== totalPoints - 1) {
+          xAxisTicks.push([totalPoints - 1, xTickLabels[totalPoints - 1] || ""]);
+        }
       }
 
       var oddsHistoryPlaceholder = $("#odds_history_placeholder<%=idx%>");
@@ -597,9 +642,7 @@ $(document).ready(function() {
             min: xMin,
             max: xMax,
             tickDecimals: 0,
-            tickFormatter: function(value) {
-              return xTickLabels[Math.round(value)] || "";
-            },
+            ticks: xAxisTicks,
           },
           yaxis: { min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks },
           yaxes: [{ min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks }],
@@ -675,7 +718,7 @@ $(document).ready(function() {
 
         oddsHistoryTooltip.html(
           (series.label || "") + "<br>" +
-          (pointMeta.recorded_on || "-") + "<br>" +
+          (formatOddsHistoryDate(pointMeta.recorded_on, fullDateFormatter, true) || "-") + "<br>" +
           oddValue + "%<br>" +
           (pointMeta.game_label || "-") +
           (zoneOddsLines.length > 0 ? "<br>" + zoneOddsLines.join("<br>") : "")

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -631,6 +631,14 @@ $(document).ready(function() {
       var allOddsHistorySeries = oddsHistory.series;
       var selectedOddsHistoryZoneName = null;
       var normalizeZoneName = function(name) { return (name || "").toString().trim(); };
+      var darkenColor = function(color, factor) {
+        if (!color || !$.color || !$.color.parse) { return color; }
+        return $.color.parse(color).scale("rgb", factor).toString();
+      };
+      var colorWithAlpha = function(color, alpha) {
+        if (!color || !$.color || !$.color.parse) { return color; }
+        return $.color.parse(color).scale("a", alpha).toString();
+      };
 
       function renderOddsHistorySeries() {
         var oddsHistoryYAxisTicks = [
@@ -648,12 +656,18 @@ $(document).ready(function() {
           })
           .map(function(series) {
             var seriesCopy = $.extend({}, series);
+            var baseSeriesColor = series.color || "#999999";
             seriesCopy.data = (series.data || []).map(function(point) {
               var timestamp = point[0];
               var fixedX = Object.prototype.hasOwnProperty.call(xValueMap, timestamp) ? xValueMap[timestamp] : timestamp;
               return [fixedX, point[1]];
             });
             seriesCopy.point_meta = (series.point_meta || []).slice();
+            seriesCopy.color = darkenColor(baseSeriesColor, 0.72);
+            seriesCopy.lines = $.extend({}, series.lines || {}, {
+              fillColor: colorWithAlpha(baseSeriesColor, 0.85),
+              lineWidth: 1.2,
+            });
             return seriesCopy;
           });
 

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -507,6 +507,19 @@ $(document).ready(function() {
     };
     options["yaxes"][0]["transform"] = function (v) { return -v; };
     options["yaxes"][0]["inverseTransform"] = function (v) { return -v; };
+    if (options["yaxes"] && options["yaxes"][0]) {
+      if ($.isArray(options["yaxes"][0]["ticks"])) {
+        options["yaxes"][0]["ticks"] = options["yaxes"][0]["ticks"].map(function(tick) {
+          if ($.isArray(tick)) {
+            return [tick[0], ""];
+          }
+          return [tick, ""];
+        });
+      } else {
+        options["yaxes"][0]["tickFormatter"] = function() { return ""; };
+      }
+      options["yaxes"][0]["showTickLabels"] = "none";
+    }
     options["xaxes"][1]["ticks"] = function (axis) {
       var res = [];
       for (var i = 0.5; i < axis.max; i += 2) {

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -663,7 +663,7 @@ $(document).ready(function() {
               return [fixedX, point[1]];
             });
             seriesCopy.point_meta = (series.point_meta || []).slice();
-            seriesCopy.color = darkenColor(baseSeriesColor, 0.72);
+            seriesCopy.color = darkenColor(baseSeriesColor, 0.82);
             seriesCopy.lines = $.extend({}, series.lines || {}, {
               fillColor: colorWithAlpha(baseSeriesColor, 0.85),
               lineWidth: 1.2,

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -472,7 +472,7 @@ $(document).ready(function() {
       <div class="odds-history-wrapper" id="odds-history-wrapper-<%=idx%>">
         <h3><%= _("Odds evolution") %></h3>
         <div id="odds_history_placeholder<%=idx%>" style="width: 550px;
-          height: 220px;
+          height: 300px;
           font-size: 14px;
           line-height: 1.2em;"></div>
         <div id="odds_history_legend<%=idx%>" class="odds-history-legend"></div>

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -616,7 +616,6 @@ $(document).ready(function() {
             hoverable: true,
             clickable: false,
             borderWidth: 1,
-            margin: { left: 8 },
             backgroundColor: "#fff",
           },
         });

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -475,7 +475,7 @@ $(document).ready(function() {
           height: 220px;
           font-size: 14px;
           line-height: 1.2em;"></div>
-        <div id="odds_history_legend<%=idx%>"></div>
+        <div id="odds_history_legend<%=idx%>" class="odds-history-legend"></div>
       </div>
       <div>
         <div id="placeholder<%=idx%>" style="width: 550px;
@@ -568,6 +568,15 @@ $(document).ready(function() {
       var normalizeZoneName = function(name) { return (name || "").toString().trim(); };
 
       function renderOddsHistorySeries() {
+        var oddsHistoryYAxisTicks = [
+          [0.0, "0.0"],
+          [0.2, "0.2"],
+          [0.4, "0.4"],
+          [0.6, "0.6"],
+          [0.8, "0.8"],
+          [1.0, "1.0"],
+        ];
+
         var seriesToRender = allOddsHistorySeries
           .filter(function(series) {
             return !selectedOddsHistoryZoneName || ((series.zone_names || []).map(normalizeZoneName).includes(selectedOddsHistoryZoneName));
@@ -592,8 +601,8 @@ $(document).ready(function() {
               return xTickLabels[Math.round(value)] || "";
             },
           },
-          yaxis: { min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: [0, 20, 40, 60, 80, 100] },
-          yaxes: [{ min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: [0, 20, 40, 60, 80, 100] }],
+          yaxis: { min: 0, max: 1, autoScale: false, reserveSpace: true, tickDecimals: 1, ticks: oddsHistoryYAxisTicks },
+          yaxes: [{ min: 0, max: 1, autoScale: false, reserveSpace: true, tickDecimals: 1, ticks: oddsHistoryYAxisTicks }],
           series: {
             stack: true,
             lines: { show: true, fill: 0.85, lineWidth: 1 },
@@ -606,7 +615,8 @@ $(document).ready(function() {
           grid: {
             hoverable: true,
             clickable: false,
-            margin: { left: 12 },
+            borderWidth: 1,
+            margin: { left: 8 },
             backgroundColor: "#fff",
           },
         });
@@ -779,6 +789,12 @@ function load_graph_data(index) {
 #panel .flot-x-axis, #panel .flot-y-axis {
   font-size: 12px;
   fill: rgb(255, 255, 255);
+}
+.odds-history-legend {
+  margin-top: 12px;
+}
+.odds-history-wrapper {
+  margin-bottom: 24px;
 }
 </style>
 <%= render partial: "shared/player_stats_table", locals: {

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -478,6 +478,7 @@ $(document).ready(function() {
         <div id="odds_history_legend<%=idx%>" class="odds-history-legend"></div>
       </div>
       <div>
+        <h3><%= _("Position and points evolution") %></h3>
         <div id="placeholder<%=idx%>" style="width: 550px;
           height: 300px;
           font-size: 14px;

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -501,10 +501,19 @@ $(document).ready(function() {
   $(function() {
     var graphDiv = $("#placeholder<%=idx%>");
     var options = data[<%=idx%>]["options"];
+    options["grid"] = options["grid"] || {};
+    options["grid"]["borderWidth"] = 1;
+    options["grid"]["labelMargin"] = 0;
+    options["grid"]["axisMargin"] = 0;
     options["legend"] = {
         container: document.getElementById('legend<%=idx%>'),
         show: true,
     };
+    if (options["xaxes"]) {
+      for (var axisIndex = 0; axisIndex < options["xaxes"].length; axisIndex++) {
+        options["xaxes"][axisIndex]["tickLength"] = "full";
+      }
+    }
     options["yaxes"][0]["transform"] = function (v) { return -v; };
     options["yaxes"][0]["inverseTransform"] = function (v) { return -v; };
     if (options["yaxes"] && options["yaxes"][0]) {
@@ -518,6 +527,8 @@ $(document).ready(function() {
       } else {
         options["yaxes"][0]["tickFormatter"] = function() { return ""; };
       }
+      options["yaxes"][0]["labelWidth"] = 0;
+      options["yaxes"][0]["tickLength"] = "full";
       options["yaxes"][0]["showTickLabels"] = "none";
     }
     options["xaxes"][1]["ticks"] = function (axis) {
@@ -651,9 +662,10 @@ $(document).ready(function() {
             max: xMax,
             tickDecimals: 0,
             ticks: xAxisTicks,
+            tickLength: "full",
           },
-          yaxis: { min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks },
-          yaxes: [{ min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks }],
+          yaxis: { min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks, labelWidth: 0, tickLength: "full" },
+          yaxes: [{ min: 0, max: 100, autoScale: false, reserveSpace: true, ticks: oddsHistoryYAxisTicks, labelWidth: 0, tickLength: "full" }],
           series: {
             stack: true,
             lines: { show: true, fill: 0.85, lineWidth: 1 },
@@ -667,6 +679,8 @@ $(document).ready(function() {
             hoverable: true,
             clickable: false,
             borderWidth: 1,
+            labelMargin: 0,
+            axisMargin: 0,
             backgroundColor: "#fff",
           },
         });

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -1326,6 +1326,9 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
+msgid "Position and points evolution"
+msgstr ""
+
 msgid "Position|P"
 msgstr ""
 

--- a/locale/pt_BR/app.po
+++ b/locale/pt_BR/app.po
@@ -1398,6 +1398,9 @@ msgstr "Pos"
 msgid "Position"
 msgstr "Posição"
 
+msgid "Position and points evolution"
+msgstr "Evolução da posição e dos pontos"
+
 msgid "Position|P"
 msgstr "P"
 


### PR DESCRIPTION
Adjust odds history graph borders, y-axis ticks, and spacing to improve readability.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-198dc107-2e10-458d-ae4d-e34d29dc9d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-198dc107-2e10-458d-ae4d-e34d29dc9d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

