### PR TITLE
Optimize and stabilize odds history backfill snapshot power calculation

### DIFF
--- a/app/controllers/group_controller.rb
+++ b/app/controllers/group_controller.rb
@@ -82,14 +82,12 @@ class GroupController < ApplicationController
     phase_id = params["phase"].presence
     from_date = params["from"].present? ? Date.parse(params["from"]) : nil
     to_date = params["to"].present? ? Date.parse(params["to"]) : nil
-    reset = params["reset"].to_s == "true"
-
     @backfill_started = OddsHistoryBackfillService.start_async(
       championship_id: championship_id,
       phase_id: phase_id,
       from_date: from_date,
       to_date: to_date,
-      reset: reset,
+      reset: true,
     ) == :started
   rescue ArgumentError
     @backfill_started = false

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -153,18 +153,18 @@ class Game < ApplicationRecord
       end
     end
 
-    def home_power
-      if home_rating.nil? or away_rating.nil?
+    def home_power(home_rating_arg = home_rating, away_rating_arg = away_rating)
+      if home_rating_arg.nil? or away_rating_arg.nil?
         return nil
       end
-      [10.0, [0.01, (home_rating.off_rating.to_f - AVG_BASE)/(AVG_BASE*0.424+0.548)*([0.25, (away_rating.def_rating.to_f+left_advantage)*0.424+0.548].max)+(away_rating.def_rating.to_f+left_advantage)].max].min
+      [10.0, [0.01, (home_rating_arg.off_rating.to_f - AVG_BASE)/(AVG_BASE*0.424+0.548)*([0.25, (away_rating_arg.def_rating.to_f+left_advantage)*0.424+0.548].max)+(away_rating_arg.def_rating.to_f+left_advantage)].max].min
     end
 
-    def away_power
-      if home_rating.nil? or away_rating.nil?
+    def away_power(home_rating_arg = home_rating, away_rating_arg = away_rating)
+      if home_rating_arg.nil? or away_rating_arg.nil?
         return nil
       end
-      [10.0, [0.01, (away_rating.off_rating.to_f - AVG_BASE)/(AVG_BASE*0.424+0.548)*([0.25, (home_rating.def_rating.to_f-left_advantage)*0.424+0.548].max)+(home_rating.def_rating.to_f-left_advantage)].max].min
+      [10.0, [0.01, (away_rating_arg.off_rating.to_f - AVG_BASE)/(AVG_BASE*0.424+0.548)*([0.25, (home_rating_arg.def_rating.to_f-left_advantage)*0.424+0.548].max)+(home_rating_arg.def_rating.to_f-left_advantage)].max].min
     end
 
     def odds

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -81,8 +81,7 @@ class OddsHistoryBackfillService
         group.team_groups.find_each { |team_group| team_group.odds_histories.delete_all }
       end
 
-      base_games_json = group.games.includes(:home, :away).as_json(
-        methods: [:home_power, :away_power],
+      base_games_json = group.games.as_json(
         only: [ :id, :home_id, :away_id, :home_score, :away_score, :played, :date, :home_field ]
       )
 
@@ -128,18 +127,21 @@ class OddsHistoryBackfillService
         snapshot_ratings_by_team = {}
 
         games_json_for_day = games_with_state.map do |game|
-          home_power = game["home_power"]
-          away_power = game["away_power"]
+          game_reference_date = if game["_snapshot_played"]
+            game["_snapshot_date"]
+          else
+            rating_reference_date
+          end
 
-          unless game["_snapshot_played"]
-            home_rating = snapshot_ratings_by_team[game["home_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["home_id"], []), rating_reference_date)
-            away_rating = snapshot_ratings_by_team[game["away_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["away_id"], []), rating_reference_date)
+          home_power = nil
+          away_power = nil
+          if game_reference_date.present?
+            snapshot_team_ratings = snapshot_ratings_by_team[game_reference_date] ||= {}
+            home_rating = snapshot_team_ratings[game["home_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["home_id"], []), game_reference_date)
+            away_rating = snapshot_team_ratings[game["away_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["away_id"], []), game_reference_date)
             power_game = Game.new(home_field: game["home_field"])
-            snapshot_home_power = power_game.home_power(home_rating, away_rating)
-            snapshot_away_power = power_game.away_power(home_rating, away_rating)
-
-            home_power = snapshot_home_power unless snapshot_home_power.nil?
-            away_power = snapshot_away_power unless snapshot_away_power.nil?
+            home_power = power_game.home_power(home_rating, away_rating)
+            away_power = power_game.away_power(home_rating, away_rating)
           end
 
           {

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -71,6 +71,7 @@ class OddsHistoryBackfillService
         methods: [:home_power, :away_power],
         only: [ :id, :home_id, :away_id, :home_score, :away_score, :played, :date ]
       )
+      base_games_json = base_games_json.uniq { |game| game["id"] }
 
       played_game_days = base_games_json
         .select { |game| game["played"] && game["date"].present? }

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -51,31 +51,6 @@ class OddsHistoryBackfillService
     end
   end
 
-  def self.left_advantage_for(home_field)
-    case home_field.to_s
-    when "left", "0"
-      Game::HOME_ADV
-    when "neutral", "1"
-      0.0
-    when "right", "2"
-      -Game::HOME_ADV
-    else
-      Game::HOME_ADV
-    end
-  end
-
-  def self.calculate_powers_for_snapshot(home_rating:, away_rating:, home_field:)
-    return [ nil, nil ] if home_rating.nil? || away_rating.nil?
-
-    left_advantage = left_advantage_for(home_field)
-    avg_base = Game::AVG_BASE
-
-    home_power = [10.0, [0.01, (home_rating.off_rating.to_f - avg_base) / (avg_base * 0.424 + 0.548) * ([0.25, (away_rating.def_rating.to_f + left_advantage) * 0.424 + 0.548].max) + (away_rating.def_rating.to_f + left_advantage)].max].min
-    away_power = [10.0, [0.01, (away_rating.off_rating.to_f - avg_base) / (avg_base * 0.424 + 0.548) * ([0.25, (home_rating.def_rating.to_f - left_advantage) * 0.424 + 0.548].max) + (home_rating.def_rating.to_f - left_advantage)].max].min
-
-    [ home_power, away_power ]
-  end
-
   def self.run_unlocked(championship_id:, phase_id: nil, group_id: nil, from_date: nil, to_date: nil, reset: false)
     groups = Group.joins(:phase)
       .where(phases: { championship_id: championship_id })
@@ -145,11 +120,9 @@ class OddsHistoryBackfillService
           unless game["_snapshot_played"]
             home_rating = ratings_by_team.fetch(game["home_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
             away_rating = ratings_by_team.fetch(game["away_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
-            snapshot_home_power, snapshot_away_power = calculate_powers_for_snapshot(
-              home_rating: home_rating,
-              away_rating: away_rating,
-              home_field: game["home_field"],
-            )
+            power_game = Game.new(home_field: game["home_field"])
+            snapshot_home_power = power_game.home_power(home_rating, away_rating)
+            snapshot_away_power = power_game.away_power(home_rating, away_rating)
 
             home_power = snapshot_home_power unless snapshot_home_power.nil?
             away_power = snapshot_away_power unless snapshot_away_power.nil?

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -93,9 +93,32 @@ class OddsHistoryBackfillService
       end
 
       game_days.each_with_index do |day, idx|
-        games_json_for_day = base_games_json.map do |game|
+        games_with_state = base_games_json.map do |game|
           game_date = game["date"].present? ? Date.parse(game["date"].to_s) : nil
           should_be_played = game["played"] && game_date.present? && game_date <= day
+
+          game.merge(
+            "_snapshot_date" => game_date,
+            "_snapshot_played" => should_be_played,
+          )
+        end
+
+        last_played_game = games_with_state
+          .select { |game| game["_snapshot_played"] }
+          .max_by { |game| [ game["_snapshot_date"], game["id"] ] }
+
+        games_json_for_day = games_with_state.map do |game|
+          home_power = if !game["_snapshot_played"] && last_played_game.present?
+            last_played_game["home_power"]
+          else
+            game["home_power"]
+          end
+
+          away_power = if !game["_snapshot_played"] && last_played_game.present?
+            last_played_game["away_power"]
+          else
+            game["away_power"]
+          end
 
           {
             "id" => game["id"],
@@ -103,9 +126,9 @@ class OddsHistoryBackfillService
             "away_id" => game["away_id"],
             "home_score" => game["home_score"],
             "away_score" => game["away_score"],
-            "played" => should_be_played,
-            "home_power" => game["home_power"],
-            "away_power" => game["away_power"],
+            "played" => game["_snapshot_played"],
+            "home_power" => home_power,
+            "away_power" => away_power,
           }
         end
 

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -68,9 +68,13 @@ class OddsHistoryBackfillService
     groups = groups.where(phase_id: phase_id) if phase_id.present?
     groups = groups.where(id: group_id) if group_id.present?
 
-    puts "Backfilling odds history for #{groups.size} group(s)"
+    group_records = groups.to_a
+    puts "Backfilling odds history for #{group_records.size} group(s)"
 
-    groups.find_each do |group|
+    all_team_ids = group_records.flat_map { |group| group.team_groups.map(&:team_id) }.uniq
+    ratings_by_team = HistoricalRating.where(team_id: all_team_ids).order(:measure_date).group_by(&:team_id)
+
+    group_records.each do |group|
       puts "-> Group ##{group.id} (#{group.name})"
 
       if reset
@@ -88,8 +92,6 @@ class OddsHistoryBackfillService
         .uniq
         .sort
 
-      team_ids = base_games_json.flat_map { |game| [ game["home_id"], game["away_id"] ] }.compact.uniq
-      ratings_by_team = HistoricalRating.where(team_id: team_ids).order(:measure_date).group_by(&:team_id)
 
       game_days = played_game_days.dup
       if played_game_days.any?

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -51,6 +51,16 @@ class OddsHistoryBackfillService
     end
   end
 
+  def self.latest_rating_before(ratings, reference_date)
+    return nil if ratings.blank?
+
+    idx = ratings.bsearch_index { |rating| rating.measure_date >= reference_date }
+    return ratings.last if idx.nil?
+    return nil if idx.zero?
+
+    ratings[idx - 1]
+  end
+
   def self.run_unlocked(championship_id:, phase_id: nil, group_id: nil, from_date: nil, to_date: nil, reset: false)
     groups = Group.joins(:phase)
       .where(phases: { championship_id: championship_id })
@@ -113,13 +123,15 @@ class OddsHistoryBackfillService
           .max
         rating_reference_date = last_played_date.present? ? (last_played_date + 1.day) : (day + 1.day)
 
+        snapshot_ratings_by_team = {}
+
         games_json_for_day = games_with_state.map do |game|
           home_power = game["home_power"]
           away_power = game["away_power"]
 
           unless game["_snapshot_played"]
-            home_rating = ratings_by_team.fetch(game["home_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
-            away_rating = ratings_by_team.fetch(game["away_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
+            home_rating = snapshot_ratings_by_team[game["home_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["home_id"], []), rating_reference_date)
+            away_rating = snapshot_ratings_by_team[game["away_id"]] ||= latest_rating_before(ratings_by_team.fetch(game["away_id"], []), rating_reference_date)
             power_game = Game.new(home_field: game["home_field"])
             snapshot_home_power = power_game.home_power(home_rating, away_rating)
             snapshot_away_power = power_game.away_power(home_rating, away_rating)

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -51,6 +51,31 @@ class OddsHistoryBackfillService
     end
   end
 
+  def self.left_advantage_for(home_field)
+    case home_field.to_s
+    when "left", "0"
+      Game::HOME_ADV
+    when "neutral", "1"
+      0.0
+    when "right", "2"
+      -Game::HOME_ADV
+    else
+      Game::HOME_ADV
+    end
+  end
+
+  def self.calculate_powers_for_snapshot(home_rating:, away_rating:, home_field:)
+    return [ nil, nil ] if home_rating.nil? || away_rating.nil?
+
+    left_advantage = left_advantage_for(home_field)
+    avg_base = Game::AVG_BASE
+
+    home_power = [10.0, [0.01, (home_rating.off_rating.to_f - avg_base) / (avg_base * 0.424 + 0.548) * ([0.25, (away_rating.def_rating.to_f + left_advantage) * 0.424 + 0.548].max) + (away_rating.def_rating.to_f + left_advantage)].max].min
+    away_power = [10.0, [0.01, (away_rating.off_rating.to_f - avg_base) / (avg_base * 0.424 + 0.548) * ([0.25, (home_rating.def_rating.to_f - left_advantage) * 0.424 + 0.548].max) + (home_rating.def_rating.to_f - left_advantage)].max].min
+
+    [ home_power, away_power ]
+  end
+
   def self.run_unlocked(championship_id:, phase_id: nil, group_id: nil, from_date: nil, to_date: nil, reset: false)
     groups = Group.joins(:phase)
       .where(phases: { championship_id: championship_id })
@@ -69,15 +94,17 @@ class OddsHistoryBackfillService
 
       base_games_json = group.games.includes(:home, :away).as_json(
         methods: [:home_power, :away_power],
-        only: [ :id, :home_id, :away_id, :home_score, :away_score, :played, :date ]
+        only: [ :id, :home_id, :away_id, :home_score, :away_score, :played, :date, :home_field ]
       )
-      base_games_json = base_games_json.uniq { |game| game["id"] }
 
       played_game_days = base_games_json
         .select { |game| game["played"] && game["date"].present? }
         .map { |game| Date.parse(game["date"].to_s) }
         .uniq
         .sort
+
+      team_ids = base_games_json.flat_map { |game| [ game["home_id"], game["away_id"] ] }.compact.uniq
+      ratings_by_team = HistoricalRating.where(team_id: team_ids).order(:measure_date).group_by(&:team_id)
 
       game_days = played_game_days.dup
       if played_game_days.any?
@@ -104,21 +131,28 @@ class OddsHistoryBackfillService
           )
         end
 
-        first_unplayed_game = games_with_state
-          .reject { |game| game["_snapshot_played"] }
-          .min_by { |game| [ game["_snapshot_date"] || Date.new(9999, 12, 31), game["id"] ] }
+        last_played_date = games_with_state
+          .select { |game| game["_snapshot_played"] }
+          .map { |game| game["_snapshot_date"] }
+          .compact
+          .max
+        rating_reference_date = last_played_date.present? ? (last_played_date + 1.day) : (day + 1.day)
 
         games_json_for_day = games_with_state.map do |game|
-          home_power = if !game["_snapshot_played"] && first_unplayed_game.present?
-            first_unplayed_game["home_power"]
-          else
-            game["home_power"]
-          end
+          home_power = game["home_power"]
+          away_power = game["away_power"]
 
-          away_power = if !game["_snapshot_played"] && first_unplayed_game.present?
-            first_unplayed_game["away_power"]
-          else
-            game["away_power"]
+          unless game["_snapshot_played"]
+            home_rating = ratings_by_team.fetch(game["home_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
+            away_rating = ratings_by_team.fetch(game["away_id"], []).select { |rating| rating.measure_date < rating_reference_date }.max_by(&:measure_date)
+            snapshot_home_power, snapshot_away_power = calculate_powers_for_snapshot(
+              home_rating: home_rating,
+              away_rating: away_rating,
+              home_field: game["home_field"],
+            )
+
+            home_power = snapshot_home_power unless snapshot_home_power.nil?
+            away_power = snapshot_away_power unless snapshot_away_power.nil?
           end
 
           {

--- a/app/services/odds_history_backfill_service.rb
+++ b/app/services/odds_history_backfill_service.rb
@@ -103,19 +103,19 @@ class OddsHistoryBackfillService
           )
         end
 
-        last_played_game = games_with_state
-          .select { |game| game["_snapshot_played"] }
-          .max_by { |game| [ game["_snapshot_date"], game["id"] ] }
+        first_unplayed_game = games_with_state
+          .reject { |game| game["_snapshot_played"] }
+          .min_by { |game| [ game["_snapshot_date"] || Date.new(9999, 12, 31), game["id"] ] }
 
         games_json_for_day = games_with_state.map do |game|
-          home_power = if !game["_snapshot_played"] && last_played_game.present?
-            last_played_game["home_power"]
+          home_power = if !game["_snapshot_played"] && first_unplayed_game.present?
+            first_unplayed_game["home_power"]
           else
             game["home_power"]
           end
 
-          away_power = if !game["_snapshot_played"] && last_played_game.present?
-            last_played_game["away_power"]
+          away_power = if !game["_snapshot_played"] && first_unplayed_game.present?
+            first_unplayed_game["away_power"]
           else
             game["away_power"]
           end

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -144,21 +144,20 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
     june_first_snapshot = fake_group.captured_games_json[1].find { |game| game["id"] == 3 }
     june_fifth_snapshot = fake_group.captured_games_json[2].find { |game| game["id"] == 3 }
 
-    expected_pre = OddsHistoryBackfillService.calculate_powers_for_snapshot(
-      home_rating: all_ratings[0],
-      away_rating: all_ratings[1],
-      home_field: "left",
-    )
-    expected_june_first = OddsHistoryBackfillService.calculate_powers_for_snapshot(
-      home_rating: all_ratings[2],
-      away_rating: all_ratings[3],
-      home_field: "left",
-    )
-    expected_june_fifth = OddsHistoryBackfillService.calculate_powers_for_snapshot(
-      home_rating: all_ratings[4],
-      away_rating: all_ratings[5],
-      home_field: "left",
-    )
+    game_for_power = Game.new(home_field: "left")
+
+    expected_pre = [
+      game_for_power.home_power(all_ratings[0], all_ratings[1]),
+      game_for_power.away_power(all_ratings[0], all_ratings[1]),
+    ]
+    expected_june_first = [
+      game_for_power.home_power(all_ratings[2], all_ratings[3]),
+      game_for_power.away_power(all_ratings[2], all_ratings[3]),
+    ]
+    expected_june_fifth = [
+      game_for_power.home_power(all_ratings[4], all_ratings[5]),
+      game_for_power.away_power(all_ratings[4], all_ratings[5]),
+    ]
 
     assert_in_delta expected_pre[0], pre_play_snapshot["home_power"], 0.000001
     assert_in_delta expected_pre[1], pre_play_snapshot["away_power"], 0.000001

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -85,6 +85,17 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
         "away_power" => 0.9,
       },
       {
+        "id" => 1,
+        "home_id" => 10,
+        "away_id" => 20,
+        "home_score" => 1,
+        "away_score" => 0,
+        "played" => true,
+        "date" => "2024-06-01",
+        "home_power" => 9.9,
+        "away_power" => 9.9,
+      },
+      {
         "id" => 2,
         "home_id" => 30,
         "away_id" => 40,
@@ -121,6 +132,7 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
     june_tenth_snapshot = fake_group.captured_games_json[3]
 
     assert_equal false, pre_play_snapshot.find { |game| game["id"] == 1 }["played"]
+    assert_equal 3, pre_play_snapshot.size
 
     pre_play_unplayed_game = pre_play_snapshot.find { |game| game["id"] == 3 }
     june_first_unplayed_game = june_first_snapshot.find { |game| game["id"] == 3 }

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -1,0 +1,130 @@
+require "test_helper"
+
+class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
+  class FakeRelation
+    def initialize(group)
+      @group = group
+    end
+
+    def where(*_args)
+      self
+    end
+
+    def includes(*_args)
+      self
+    end
+
+    def size
+      1
+    end
+
+    def find_each
+      yield @group
+    end
+  end
+
+  class FakeGames
+    def initialize(base_games_json)
+      @base_games_json = base_games_json
+    end
+
+    def includes(*_args)
+      self
+    end
+
+    def as_json(*_args)
+      @base_games_json
+    end
+  end
+
+  class FakeTeamGroups
+    def find_each
+    end
+  end
+
+  class FakeGroup
+    attr_reader :captured_games_json
+
+    def initialize(base_games_json)
+      @games = FakeGames.new(base_games_json)
+      @captured_games_json = []
+    end
+
+    def id
+      99
+    end
+
+    def name
+      "Test Group"
+    end
+
+    def team_groups
+      FakeTeamGroups.new
+    end
+
+    def games
+      @games
+    end
+
+    def odds(games_json:, **_args)
+      @captured_games_json << games_json
+    end
+  end
+
+  test "uses home power from last played game for unplayed games during backfill" do
+    base_games_json = [
+      {
+        "id" => 1,
+        "home_id" => 10,
+        "away_id" => 20,
+        "home_score" => 1,
+        "away_score" => 0,
+        "played" => true,
+        "date" => "2024-06-01",
+        "home_power" => 1.1,
+        "away_power" => 0.9,
+      },
+      {
+        "id" => 2,
+        "home_id" => 30,
+        "away_id" => 40,
+        "home_score" => 2,
+        "away_score" => 1,
+        "played" => true,
+        "date" => "2024-06-05",
+        "home_power" => 2.2,
+        "away_power" => 1.1,
+      },
+      {
+        "id" => 3,
+        "home_id" => 50,
+        "away_id" => 60,
+        "home_score" => nil,
+        "away_score" => nil,
+        "played" => false,
+        "date" => "2024-06-10",
+        "home_power" => 3.3,
+        "away_power" => 1.4,
+      },
+    ]
+
+    fake_group = FakeGroup.new(base_games_json)
+    fake_relation = FakeRelation.new(fake_group)
+
+    Group.stub(:joins, fake_relation) do
+      OddsHistoryBackfillService.run_unlocked(championship_id: 1)
+    end
+
+    june_first_snapshot = fake_group.captured_games_json[1]
+    june_fifth_snapshot = fake_group.captured_games_json[2]
+
+    june_first_unplayed_game = june_first_snapshot.find { |game| game["id"] == 3 }
+    june_fifth_unplayed_game = june_fifth_snapshot.find { |game| game["id"] == 3 }
+
+    assert_equal 1.1, june_first_unplayed_game["home_power"]
+    assert_equal 0.9, june_first_unplayed_game["away_power"]
+
+    assert_equal 2.2, june_fifth_unplayed_game["home_power"]
+    assert_equal 1.1, june_fifth_unplayed_game["away_power"]
+  end
+end

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -38,6 +38,16 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
   end
 
   class FakeTeamGroups
+    def initialize(team_ids)
+      @team_ids = team_ids
+    end
+
+    def map
+      return enum_for(:map) unless block_given?
+
+      @team_ids.map { |team_id| yield Struct.new(:team_id).new(team_id) }
+    end
+
     def find_each
     end
   end
@@ -59,7 +69,8 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
     end
 
     def team_groups
-      FakeTeamGroups.new
+      ids = @games.as_json.flat_map { |game| [ game["home_id"], game["away_id"] ] }.compact.uniq
+      FakeTeamGroups.new(ids)
     end
 
     def games

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -71,7 +71,17 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "uses powers from first unplayed game and includes a pre-play snapshot" do
+  class FakeHistoricalScope
+    def initialize(ratings)
+      @ratings = ratings
+    end
+
+    def order(*_args)
+      @ratings.sort_by(&:measure_date)
+    end
+  end
+
+  test "uses ratings from day after last played game when backfilling each snapshot" do
     base_games_json = [
       {
         "id" => 1,
@@ -81,19 +91,9 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
         "away_score" => 0,
         "played" => true,
         "date" => "2024-06-01",
+        "home_field" => "left",
         "home_power" => 1.1,
         "away_power" => 0.9,
-      },
-      {
-        "id" => 1,
-        "home_id" => 10,
-        "away_id" => 20,
-        "home_score" => 1,
-        "away_score" => 0,
-        "played" => true,
-        "date" => "2024-06-01",
-        "home_power" => 9.9,
-        "away_power" => 9.9,
       },
       {
         "id" => 2,
@@ -103,6 +103,7 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
         "away_score" => 1,
         "played" => true,
         "date" => "2024-06-05",
+        "home_field" => "left",
         "home_power" => 2.2,
         "away_power" => 1.1,
       },
@@ -114,42 +115,58 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
         "away_score" => 0,
         "played" => true,
         "date" => "2024-06-10",
+        "home_field" => "left",
         "home_power" => 3.3,
         "away_power" => 1.4,
       },
+    ]
+
+    rating = Struct.new(:team_id, :measure_date, :off_rating, :def_rating)
+    all_ratings = [
+      rating.new(50, Date.parse("2024-05-30"), 1.2, 1.0),
+      rating.new(60, Date.parse("2024-05-30"), 1.1, 0.9),
+      rating.new(50, Date.parse("2024-06-01"), 1.8, 1.2),
+      rating.new(60, Date.parse("2024-06-01"), 1.6, 1.4),
+      rating.new(50, Date.parse("2024-06-05"), 2.6, 1.8),
+      rating.new(60, Date.parse("2024-06-05"), 2.1, 1.9),
     ]
 
     fake_group = FakeGroup.new(base_games_json)
     fake_relation = FakeRelation.new(fake_group)
 
     Group.stub(:joins, fake_relation) do
-      OddsHistoryBackfillService.run_unlocked(championship_id: 1)
+      HistoricalRating.stub(:where, FakeHistoricalScope.new(all_ratings)) do
+        OddsHistoryBackfillService.run_unlocked(championship_id: 1)
+      end
     end
 
-    pre_play_snapshot = fake_group.captured_games_json[0]
-    june_first_snapshot = fake_group.captured_games_json[1]
-    june_fifth_snapshot = fake_group.captured_games_json[2]
-    june_tenth_snapshot = fake_group.captured_games_json[3]
+    pre_play_snapshot = fake_group.captured_games_json[0].find { |game| game["id"] == 3 }
+    june_first_snapshot = fake_group.captured_games_json[1].find { |game| game["id"] == 3 }
+    june_fifth_snapshot = fake_group.captured_games_json[2].find { |game| game["id"] == 3 }
 
-    assert_equal false, pre_play_snapshot.find { |game| game["id"] == 1 }["played"]
-    assert_equal 3, pre_play_snapshot.size
+    expected_pre = OddsHistoryBackfillService.calculate_powers_for_snapshot(
+      home_rating: all_ratings[0],
+      away_rating: all_ratings[1],
+      home_field: "left",
+    )
+    expected_june_first = OddsHistoryBackfillService.calculate_powers_for_snapshot(
+      home_rating: all_ratings[2],
+      away_rating: all_ratings[3],
+      home_field: "left",
+    )
+    expected_june_fifth = OddsHistoryBackfillService.calculate_powers_for_snapshot(
+      home_rating: all_ratings[4],
+      away_rating: all_ratings[5],
+      home_field: "left",
+    )
 
-    pre_play_unplayed_game = pre_play_snapshot.find { |game| game["id"] == 3 }
-    june_first_unplayed_game = june_first_snapshot.find { |game| game["id"] == 3 }
-    june_fifth_unplayed_game = june_fifth_snapshot.find { |game| game["id"] == 3 }
-    june_tenth_played_game = june_tenth_snapshot.find { |game| game["id"] == 3 }
+    assert_in_delta expected_pre[0], pre_play_snapshot["home_power"], 0.000001
+    assert_in_delta expected_pre[1], pre_play_snapshot["away_power"], 0.000001
 
-    assert_equal 1.1, pre_play_unplayed_game["home_power"]
-    assert_equal 0.9, pre_play_unplayed_game["away_power"]
+    assert_in_delta expected_june_first[0], june_first_snapshot["home_power"], 0.000001
+    assert_in_delta expected_june_first[1], june_first_snapshot["away_power"], 0.000001
 
-    assert_equal 2.2, june_first_unplayed_game["home_power"]
-    assert_equal 1.1, june_first_unplayed_game["away_power"]
-
-    assert_equal 3.3, june_fifth_unplayed_game["home_power"]
-    assert_equal 1.4, june_fifth_unplayed_game["away_power"]
-
-    assert_equal true, june_tenth_played_game["played"]
-    assert_equal 3.3, june_tenth_played_game["home_power"]
-    assert_equal 1.4, june_tenth_played_game["away_power"]
+    assert_in_delta expected_june_fifth[0], june_fifth_snapshot["home_power"], 0.000001
+    assert_in_delta expected_june_fifth[1], june_fifth_snapshot["away_power"], 0.000001
   end
 end

--- a/test/unit/odds_history_backfill_service_test.rb
+++ b/test/unit/odds_history_backfill_service_test.rb
@@ -71,7 +71,7 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "uses home power from last played game for unplayed games during backfill" do
+  test "uses powers from first unplayed game and includes a pre-play snapshot" do
     base_games_json = [
       {
         "id" => 1,
@@ -99,9 +99,9 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
         "id" => 3,
         "home_id" => 50,
         "away_id" => 60,
-        "home_score" => nil,
-        "away_score" => nil,
-        "played" => false,
+        "home_score" => 0,
+        "away_score" => 0,
+        "played" => true,
         "date" => "2024-06-10",
         "home_power" => 3.3,
         "away_power" => 1.4,
@@ -115,16 +115,29 @@ class OddsHistoryBackfillServiceTest < ActiveSupport::TestCase
       OddsHistoryBackfillService.run_unlocked(championship_id: 1)
     end
 
+    pre_play_snapshot = fake_group.captured_games_json[0]
     june_first_snapshot = fake_group.captured_games_json[1]
     june_fifth_snapshot = fake_group.captured_games_json[2]
+    june_tenth_snapshot = fake_group.captured_games_json[3]
 
+    assert_equal false, pre_play_snapshot.find { |game| game["id"] == 1 }["played"]
+
+    pre_play_unplayed_game = pre_play_snapshot.find { |game| game["id"] == 3 }
     june_first_unplayed_game = june_first_snapshot.find { |game| game["id"] == 3 }
     june_fifth_unplayed_game = june_fifth_snapshot.find { |game| game["id"] == 3 }
+    june_tenth_played_game = june_tenth_snapshot.find { |game| game["id"] == 3 }
 
-    assert_equal 1.1, june_first_unplayed_game["home_power"]
-    assert_equal 0.9, june_first_unplayed_game["away_power"]
+    assert_equal 1.1, pre_play_unplayed_game["home_power"]
+    assert_equal 0.9, pre_play_unplayed_game["away_power"]
 
-    assert_equal 2.2, june_fifth_unplayed_game["home_power"]
-    assert_equal 1.1, june_fifth_unplayed_game["away_power"]
+    assert_equal 2.2, june_first_unplayed_game["home_power"]
+    assert_equal 1.1, june_first_unplayed_game["away_power"]
+
+    assert_equal 3.3, june_fifth_unplayed_game["home_power"]
+    assert_equal 1.4, june_fifth_unplayed_game["away_power"]
+
+    assert_equal true, june_tenth_played_game["played"]
+    assert_equal 3.3, june_tenth_played_game["home_power"]
+    assert_equal 1.4, june_tenth_played_game["away_power"]
   end
 end


### PR DESCRIPTION
Includes:

motivation for snapshot-aligned powers + performance improvements,

detailed changes across:

app/services/odds_history_backfill_service.rb

app/models/game.rb

app/controllers/group_controller.rb

test/unit/odds_history_backfill_service_test.rb

testing section with the environment limitation (userstamp bundler dependency).




------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b4f4d6a88330a4f41a9979d35408)