### PR TITLE
Handle bracketed time params in GameController#update

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -95,8 +95,10 @@ class GameController < ApplicationController
     @game.attributes = game_params
     @game.date = params["game_date"]
     @game.has_time = false
-    unless params["hour"].empty?
-      @game.date = cookie_timezone.local_to_utc(@game.date + params["hour"].to_i.hours + params["minute"].to_i.minute)
+    hour = params["hour"] || params["[hour]"]
+    minute = params["minute"] || params["[minute]"]
+    unless hour.to_s.empty?
+      @game.date = cookie_timezone.local_to_utc(@game.date + hour.to_i.hours + minute.to_i.minute)
       @game.has_time = true
     end
     # set score to sane values


### PR DESCRIPTION
### Motivation
- Fix a `NoMethodError` occurring when form time fields are submitted with bracketed keys like `"[hour]"`/`"[minute]"` and `params["hour"]` is `nil` so `empty?` was called on `nil`.

### Description
- Normalize incoming time params with `hour = params["hour"] || params["[hour]"]` and `minute = params["minute"] || params["[minute]"]` in `GameController#update`.
- Use `hour.to_s.empty?` instead of calling `empty?` directly on `params["hour"]`, and set `@game.date` and `@game.has_time` using the normalized values.

### Testing
- Ran `bin/rails test test/functional/game_controller_test.rb`; the test run failed in this environment due to a Bundler git dependency error (the `userstamp` git dependency is not checked out), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d6329f2c83308d77d565046ec5b9)