### PR TITLE
Team strength group odds

### DIFF
--- a/app/controllers/team_controller.rb
+++ b/app/controllers/team_controller.rb
@@ -40,36 +40,7 @@ class TeamController < ApplicationController
   end
 
   def update_rating
-    all_games = Game.joins(phase: :championship).select(:home_id, :away_id, :phase_id, :home_score, :home_aet, :away_score, :away_aet, :date, :home_field).where(championships: { category_id: 1 }, played: true).where("date >= ?", DateTime.now - 4.years).where("date <= ?", DateTime.now).reorder(:date)
-    json_map = { games: all_games.pluck(:home_id, :away_id, :phase_id, :home_score, :home_aet, :away_score, :away_aet, :date, :home_field)
-          .map{|home_id, away_id, phase_id, home_score, home_aet, away_score, away_aet, date, home_field|
-        { home_id: home_id,
-          away_id: away_id,
-          phase_id: phase_id,
-          home_score: (home_score + home_aet.to_i).to_f / if home_aet.nil? then 1.0 else 4.0/3.0 end,
-          away_score: (away_score + away_aet.to_i).to_f / if home_aet.nil? then 1.0 else 4.0/3.0 end,
-          timestamp: date.to_i,
-          length: if home_aet.nil? then 1.0 else 4.0/3.0 end,
-          advantage: if home_field == Game.home_fields["left"] then Game::HOME_ADV elsif home_field == Game.home_fields["neutral"] then 0.0 else -Game::HOME_ADV end }
-    }, ratings: Team.all.pluck(:id, :off_rating, :def_rating).map{|id, off_rating, def_rating| {id: id, offense: off_rating, defense: def_rating} }}
-    req = Net::HTTP::Post.new("/spi", {'Content-Type' =>'application/json'})
-    req.body = Oj.dump(json_map, mode: :compat)
-    response = Net::HTTP.new("localhost", 6577).start {|http| http.read_timeout = 300; http.request(req) }
-    sql = "INSERT INTO teams (id,off_rating,def_rating,rating,created_at,updated_at) VALUES ";
-    sql2 = "INSERT INTO historical_ratings (team_id,off_rating,def_rating,rating,measure_date) VALUES ";
-    now = Time.zone.now.to_s.chop.chop.chop.chop
-    Oj.load(response.body, bigdecimal_load: :float).each do |k,v|
-      sql << "(#{k}, #{v ? v["Offense"] : "NULL"}, #{v ? v["Defense"] : "NULL"}, #{v ? v["Team"] : "NULL"}, '#{now}', '#{now}'),"
-      if v != nil then
-         sql2 << "(#{k}, #{v["Offense"]}, #{v["Defense"]}, #{v["Team"]}, '#{Date.today.strftime(Date::DATE_FORMATS[:db])}'),"
-      end
-    end
-    sql.chop!
-    sql2.chop!
-    sql << "ON DUPLICATE KEY UPDATE off_rating=VALUES(off_rating),def_rating=VALUES(def_rating),rating=VALUES(rating),updated_at=VALUES(updated_at);"
-    sql2 << "ON DUPLICATE KEY UPDATE off_rating=VALUES(off_rating),def_rating=VALUES(def_rating),rating=VALUES(rating);"
-    ActiveRecord::Base.connection.execute(sql)
-    ActiveRecord::Base.connection.execute(sql2)
+    Team.update_ratings
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -82,6 +82,52 @@ class Team < ApplicationRecord
     LTTB.downsample(data, threshold)
   end
 
+  def self.update_ratings
+    all_games = Game.joins(phase: :championship)
+      .select(:home_id, :away_id, :phase_id, :home_score, :home_aet, :away_score, :away_aet, :date, :home_field)
+      .where(championships: { category_id: 1 }, played: true)
+      .where("date >= ?", DateTime.now - 4.years)
+      .where("date <= ?", DateTime.now)
+      .reorder(:date)
+
+    json_map = {
+      games: all_games.pluck(:home_id, :away_id, :phase_id, :home_score, :home_aet, :away_score, :away_aet, :date, :home_field)
+        .map { |home_id, away_id, phase_id, home_score, home_aet, away_score, away_aet, date, home_field|
+          {
+            home_id: home_id,
+            away_id: away_id,
+            phase_id: phase_id,
+            home_score: (home_score + home_aet.to_i).to_f / (home_aet.nil? ? 1.0 : 4.0 / 3.0),
+            away_score: (away_score + away_aet.to_i).to_f / (home_aet.nil? ? 1.0 : 4.0 / 3.0),
+            timestamp: date.to_i,
+            length: home_aet.nil? ? 1.0 : 4.0 / 3.0,
+            advantage: if home_field == Game.home_fields["left"] then Game::HOME_ADV elsif home_field == Game.home_fields["neutral"] then 0.0 else -Game::HOME_ADV end
+          }
+        },
+      ratings: Team.all.pluck(:id, :off_rating, :def_rating).map { |id, off_rating, def_rating| { id: id, offense: off_rating, defense: def_rating } }
+    }
+
+    req = Net::HTTP::Post.new("/spi", { 'Content-Type' => 'application/json' })
+    req.body = Oj.dump(json_map, mode: :compat)
+    response = Net::HTTP.new("localhost", 6577).start { |http| http.read_timeout = 300; http.request(req) }
+
+    sql = "INSERT INTO teams (id,off_rating,def_rating,rating,created_at,updated_at) VALUES "
+    sql2 = "INSERT INTO historical_ratings (team_id,off_rating,def_rating,rating,measure_date) VALUES "
+    now = Time.zone.now.to_s.chop.chop.chop.chop
+    Oj.load(response.body, bigdecimal_load: :float).each do |k, v|
+      sql << "(#{k}, #{v ? v["Offense"] : "NULL"}, #{v ? v["Defense"] : "NULL"}, #{v ? v["Team"] : "NULL"}, '#{now}', '#{now}'),"
+      if v != nil
+        sql2 << "(#{k}, #{v["Offense"]}, #{v["Defense"]}, #{v["Team"]}, '#{Date.today.strftime(Date::DATE_FORMATS[:db])}'),"
+      end
+    end
+    sql.chop!
+    sql2.chop!
+    sql << "ON DUPLICATE KEY UPDATE off_rating=VALUES(off_rating),def_rating=VALUES(def_rating),rating=VALUES(rating),updated_at=VALUES(updated_at);"
+    sql2 << "ON DUPLICATE KEY UPDATE off_rating=VALUES(off_rating),def_rating=VALUES(def_rating),rating=VALUES(rating);"
+    ActiveRecord::Base.connection.execute(sql)
+    ActiveRecord::Base.connection.execute(sql2)
+  end
+
   def retrieve_geocode
     url = "https://nominatim.openstreetmap.org/search.php?q=#{CGI.escape(city.to_s + ", " + country)}&format=jsonv2&namedetails=1&layer=address"
     uri = URI(url)

--- a/app/services/game_data_scrape_service.rb
+++ b/app/services/game_data_scrape_service.rb
@@ -99,7 +99,7 @@ class GameDataScrapeService
 
     begin
       puts "Updating group odds for recently played games..."
-      Game.where(played: true).where("date > ?", DateTime.now - 1.hour)
+      Game.where(played: true).where("games.updated_at > ?", 1.hour.ago)
         .map { |g| g.phase }.sort.uniq
         .each do |phase|
           phase.groups.each do |g|

--- a/app/services/game_data_scrape_service.rb
+++ b/app/services/game_data_scrape_service.rb
@@ -88,5 +88,29 @@ class GameDataScrapeService
 
     workers.each(&:join)
     puts "Game data scrape finished"
+
+    begin
+      puts "Updating team ratings..."
+      Team.update_ratings
+      puts "Team ratings updated"
+    rescue => e
+      puts "ERROR updating team ratings: #{e.class}: #{e.message}"
+    end
+
+    begin
+      puts "Updating group odds for recently played games..."
+      Game.where(played: true).where("date > ?", DateTime.now - 1.hour)
+        .map { |g| g.phase }.sort.uniq
+        .each do |phase|
+          phase.groups.each do |g|
+            g.odds
+            g.odds_progress = nil
+            g.save!
+          end
+        end
+      puts "Group odds updated"
+    rescue => e
+      puts "ERROR updating group odds: #{e.class}: #{e.message}"
+    end
   end
 end


### PR DESCRIPTION
Recalculate team strength and update group odds in the hourly game data scrape to ensure data freshness.

The hourly background task now updates team ratings and group odds immediately after scraping new game data. This ensures that downstream calculations and user-facing information are based on the most current game results. The team strength update logic was also extracted into a reusable class method.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-615b6a8d-1682-4bef-86a8-c13fd24d6b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-615b6a8d-1682-4bef-86a8-c13fd24d6b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

