### PR TITLE
Odds graph x-axis spacing

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -288,6 +288,7 @@ class ChampionshipController < ApplicationController
       .to_a
 
     latest_game_by_timestamp = {}
+    matches_played_by_timestamp = {}
     game_idx = 0
     latest_game = nil
     history_by_day.each do |_, snapshot_time, _|
@@ -296,6 +297,7 @@ class ChampionshipController < ApplicationController
         game_idx += 1
       end
       latest_game_by_timestamp[snapshot_time] = latest_game
+      matches_played_by_timestamp[snapshot_time] = game_idx
     end
 
     zone_odds_by_snapshot = history_by_day.map do |_, _, odds|
@@ -335,6 +337,7 @@ class ChampionshipController < ApplicationController
         game = latest_game_by_timestamp[snapshot_time]
         points_meta << {
           recorded_on: recorded_on.to_s,
+          matches_played: matches_played_by_timestamp[snapshot_time] || 0,
           game_date: game&.date&.to_s,
           game_label: if game
                         "#{game.home.name} #{game.home_score}-#{game.away_score} #{game.away.name}"

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -550,7 +550,7 @@ $(document).ready(function() {
       var xMax = null;
       var xValueMap = {};
       var xAxisTicks = [];
-      var timestampMetaMap = {};
+      var timestampMatchCountMap = {};
       var oddsHistoryLocale = "<%= I18n.locale %>".toString().replace(/_/g, "-");
       var fullDateFormatter = null;
 
@@ -585,8 +585,9 @@ $(document).ready(function() {
       oddsHistory.series.forEach(function(series) {
         (series.data || []).forEach(function(point, pointIndex) {
           var pointMeta = (series.point_meta || [])[pointIndex] || {};
-          if (!timestampMetaMap[point[0]] && pointMeta.recorded_on) {
-            timestampMetaMap[point[0]] = pointMeta.recorded_on;
+          var parsedMatchCount = parseInt(pointMeta.matches_played, 10);
+          if (!Object.prototype.hasOwnProperty.call(timestampMatchCountMap, point[0]) && !isNaN(parsedMatchCount)) {
+            timestampMatchCountMap[point[0]] = Math.max(parsedMatchCount, 0);
           }
         });
       });
@@ -596,21 +597,60 @@ $(document).ready(function() {
           return arr.indexOf(timestamp) === index;
         }).sort(function(a, b) { return a - b; });
 
-        uniqueSortedTimestamps.forEach(function(timestamp, index) {
-          xValueMap[timestamp] = index;
+        var timestampsByMatchCount = {};
+        var maxMatchCount = 0;
+
+        uniqueSortedTimestamps.forEach(function(timestamp) {
+          var matchCount = parseInt(timestampMatchCountMap[timestamp], 10);
+          if (isNaN(matchCount) || matchCount < 0) {
+            matchCount = 0;
+          }
+          maxMatchCount = Math.max(maxMatchCount, matchCount);
+          if (!timestampsByMatchCount[matchCount]) {
+            timestampsByMatchCount[matchCount] = [];
+          }
+          timestampsByMatchCount[matchCount].push(timestamp);
         });
 
-        xMin = 0;
-        xMax = Math.max(uniqueSortedTimestamps.length - 1, 0);
+        Object.keys(timestampsByMatchCount).forEach(function(matchCountKey) {
+          var matchCount = parseInt(matchCountKey, 10);
+          var bucket = timestampsByMatchCount[matchCountKey];
+          if (!bucket || bucket.length === 0) {
+            return;
+          }
+
+          bucket.forEach(function(timestamp, bucketIndex) {
+            var xPosition = matchCount;
+            if (matchCount < maxMatchCount) {
+              xPosition = matchCount + (bucketIndex / bucket.length);
+            }
+            xValueMap[timestamp] = xPosition;
+          });
+        });
+
+        uniqueSortedTimestamps.forEach(function(timestamp, index) {
+          if (!Object.prototype.hasOwnProperty.call(xValueMap, timestamp)) {
+            xValueMap[timestamp] = index;
+          }
+        });
+
+        var normalizedPositions = uniqueSortedTimestamps.map(function(timestamp) {
+          return xValueMap[timestamp];
+        });
+        xMin = Math.min.apply(null, normalizedPositions);
+        xMax = Math.max.apply(null, normalizedPositions);
+        if (xMin === xMax) {
+          xMax = xMin + 1;
+        }
+
         var maxXAxisLabelCount = 6;
-        var totalPoints = uniqueSortedTimestamps.length;
         var denominator = Math.max(maxXAxisLabelCount - 1, 1);
-        var tickStep = Math.max(1, Math.ceil((totalPoints - 1) / denominator));
-        for (var tickPosition = 0; tickPosition < totalPoints; tickPosition += tickStep) {
+        var tickStep = Math.max(1, Math.ceil(Math.max(maxMatchCount, 1) / denominator));
+        for (var tickPosition = 0; tickPosition <= maxMatchCount; tickPosition += tickStep) {
           xAxisTicks.push([tickPosition, ""]);
         }
-        if (xAxisTicks.length === 0 || xAxisTicks[xAxisTicks.length - 1][0] !== totalPoints - 1) {
-          xAxisTicks.push([totalPoints - 1, ""]);
+        if (xAxisTicks.length === 0 || xAxisTicks[xAxisTicks.length - 1][0] !== maxMatchCount) {
+          xAxisTicks.push([maxMatchCount, ""]);
         }
       }
 

--- a/test/functional/championship_controller_test.rb
+++ b/test/functional/championship_controller_test.rb
@@ -15,4 +15,84 @@ class ChampionshipControllerTest < Test::Unit::TestCase
   def test_truth
     assert true
   end
+
+  def test_generate_odds_history_json_tracks_matches_played_with_uniform_match_steps
+    championship = Championship.create!(
+      name: "Spacing Championship",
+      begin: Date.new(2025, 1, 1),
+      end: Date.new(2025, 12, 31),
+      point_win: 3,
+      point_draw: 1,
+      point_loss: 0,
+      region: :national,
+      region_name: "Brazil",
+      category: categories(:one)
+    )
+    phase = Phase.create!(
+      championship: championship,
+      name: "Spacing Phase",
+      order_by: 1,
+      sort: "pt,gd"
+    )
+    group = Group.create!(
+      phase: phase,
+      name: "Spacing Group",
+      zones: []
+    )
+
+    team = teams(:first)
+    opponent = teams(:another)
+
+    team_group = TeamGroup.create!(group: group, team: team, add_sub: 0, bias: 0)
+    TeamGroup.create!(group: group, team: opponent, add_sub: 0, bias: 0)
+
+    Game.create!(
+      phase: phase,
+      home: team,
+      away: opponent,
+      date: Time.zone.parse("2025-01-02 12:00:00"),
+      played: true,
+      home_score: 1,
+      away_score: 0
+    )
+    Game.create!(
+      phase: phase,
+      home: opponent,
+      away: team,
+      date: Time.zone.parse("2025-01-06 12:00:00"),
+      played: true,
+      home_score: 0,
+      away_score: 2
+    )
+
+    TeamGroupOddsHistory.create!(
+      team_group: team_group,
+      recorded_on: Date.new(2025, 1, 1),
+      captured_at: Time.zone.parse("2025-01-01 23:59:00"),
+      odds: [60.0, 40.0]
+    )
+    TeamGroupOddsHistory.create!(
+      team_group: team_group,
+      recorded_on: Date.new(2025, 1, 3),
+      captured_at: Time.zone.parse("2025-01-03 23:59:00"),
+      odds: [55.0, 45.0]
+    )
+    TeamGroupOddsHistory.create!(
+      team_group: team_group,
+      recorded_on: Date.new(2025, 1, 5),
+      captured_at: Time.zone.parse("2025-01-05 23:59:00"),
+      odds: [50.0, 50.0]
+    )
+    TeamGroupOddsHistory.create!(
+      team_group: team_group,
+      recorded_on: Date.new(2025, 1, 7),
+      captured_at: Time.zone.parse("2025-01-07 23:59:00"),
+      odds: [65.0, 35.0]
+    )
+
+    payload = JSON.parse(@controller.send(:generate_odds_history_json, group, team))
+    meta = payload["series"].first["point_meta"]
+
+    assert_equal [0, 1, 1, 2], meta.map { |point_meta| point_meta["matches_played"] }
+  end
 end


### PR DESCRIPTION
Normalize team odds history graph x-axis by matches played to ensure uniform spacing between a team's matches.

---
<p><a href="https://cursor.com/agents?id=bc-9d2a0675-0f81-4e74-a957-1af0cb5b75ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d2a0675-0f81-4e74-a957-1af0cb5b75ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

