### PR TITLE
Add team game-position points to odds history chart

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -335,6 +335,7 @@ class ChampionshipController < ApplicationController
         game = latest_game_by_timestamp[snapshot_time]
         points_meta << {
           recorded_on: recorded_on.to_s,
+          game_id: game&.id,
           game_date: game&.date&.to_s,
           game_label: if game
                         "#{game.home.name} #{game.home_score}-#{game.away_score} #{game.away.name}"
@@ -346,6 +347,7 @@ class ChampionshipController < ApplicationController
       end
 
       {
+        position: position,
         label: position.ordinalize,
         zone_name: zone_name_by_position[position],
         zone_names: zone_names_by_position[position] || [],

--- a/app/views/championship/team.html.erb
+++ b/app/views/championship/team.html.erb
@@ -640,6 +640,75 @@ $(document).ready(function() {
         return $.color.parse(color).scale("a", alpha).toString();
       };
 
+      function buildGamePositionSeries(seriesToRender) {
+        var mainChartData = data[<%=idx%>] || {};
+        var positionSeries = (mainChartData.data || [])[3] || {};
+        var positionPoints = positionSeries.data || [];
+        var gameUrls = ((mainChartData.urls || [])[0]) || [];
+        var firstSnapshotByGameId = {};
+
+        seriesToRender.forEach(function(series) {
+          (series.point_meta || []).forEach(function(pointMeta, pointIndex) {
+            var gameId = pointMeta.game_id;
+            if (!gameId || Object.prototype.hasOwnProperty.call(firstSnapshotByGameId, gameId)) { return; }
+            firstSnapshotByGameId[gameId] = pointIndex;
+          });
+        });
+
+        var plotPoints = [];
+        var plotPointMeta = [];
+
+        positionPoints.forEach(function(positionPoint, gameIndex) {
+          var gameUrl = gameUrls[gameIndex] || "";
+          var gameIdMatch = gameUrl.toString().match(/(\d+)(?:\D*)$/);
+          if (!gameIdMatch) { return; }
+
+          var gameId = parseInt(gameIdMatch[1], 10);
+          if (!Object.prototype.hasOwnProperty.call(firstSnapshotByGameId, gameId)) { return; }
+
+          var snapshotIndex = firstSnapshotByGameId[gameId];
+          var position = parseInt(positionPoint[1], 10);
+          if (isNaN(position)) { return; }
+
+          var valueForPosition = 0;
+          var offsetFromBottom = 0;
+
+          seriesToRender.forEach(function(series) {
+            var seriesPosition = parseInt(series.position, 10);
+            var snapshotPoint = (series.data || [])[snapshotIndex] || [null, 0];
+            var oddValue = snapshotPoint[1] || 0;
+
+            if (seriesPosition === position) {
+              valueForPosition = oddValue;
+            }
+            if (seriesPosition > position) {
+              offsetFromBottom += oddValue;
+            }
+          });
+
+          var pointMeta = ((seriesToRender[0] || {}).point_meta || [])[snapshotIndex] || {};
+          var timestamp = (((seriesToRender[0] || {}).data || [])[snapshotIndex] || [null])[0];
+          if (timestamp === null) { return; }
+
+          plotPoints.push([timestamp, offsetFromBottom + (valueForPosition / 2.0)]);
+          plotPointMeta.push($.extend({}, pointMeta, {
+            position: position,
+            value_for_position: valueForPosition,
+          }));
+        });
+
+        return {
+          label: "<%= j(_("Position after each game")) %>",
+          data: plotPoints,
+          point_meta: plotPointMeta,
+          color: "#111111",
+          lines: { show: true, lineWidth: 2, fill: false },
+          points: { show: true, radius: 3, lineWidth: 1, fillColor: "#ffffff" },
+          stack: false,
+          shadowSize: 0,
+        };
+      }
+
       function renderOddsHistorySeries() {
         var oddsHistoryYAxisTicks = [
           [0, ""],
@@ -670,6 +739,11 @@ $(document).ready(function() {
             });
             return seriesCopy;
           });
+
+        var gamePositionSeries = buildGamePositionSeries(seriesToRender);
+        if ((gamePositionSeries.data || []).length > 0) {
+          seriesToRender.push(gamePositionSeries);
+        }
 
         oddsHistoryPlot = $.plot(oddsHistoryPlaceholder, seriesToRender, {
           xaxis: {
@@ -746,6 +820,7 @@ $(document).ready(function() {
         var pointMeta = (series.point_meta || [])[item.dataIndex] || {};
         var seriesPoint = (series.data || [])[item.dataIndex] || [null, 0];
         var oddValue = seriesPoint[1].toLocaleString("<%= I18n.locale %>", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        var isGamePositionSeries = series.label === "<%= j(_("Position after each game")) %>";
 
         var zoneOddsLines = (pointMeta.zone_odds || []).map(function(zoneOdd) {
           var zoneColor = zoneOdd.color || "#999999";
@@ -753,12 +828,14 @@ $(document).ready(function() {
           return "<span style=\"color:" + zoneColor + "\">▣</span> " + (zoneOdd.name || "") + ": " + zoneValue + "%";
         });
 
+        var valueLine = isGamePositionSeries ? ((pointMeta.position || "-") + "º") : (oddValue + "%");
+
         oddsHistoryTooltip.html(
           (series.label || "") + "<br>" +
           (formatOddsHistoryDate(pointMeta.recorded_on, fullDateFormatter, true) || "-") + "<br>" +
-          oddValue + "%<br>" +
+          valueLine + "<br>" +
           (pointMeta.game_label || "-") +
-          (zoneOddsLines.length > 0 ? "<br>" + zoneOddsLines.join("<br>") : "")
+          (!isGamePositionSeries && zoneOddsLines.length > 0 ? "<br>" + zoneOddsLines.join("<br>") : "")
         ).css({ top: pos.pageY + 5, left: pos.pageX + 5 }).fadeIn(200);
       });
     } else {


### PR DESCRIPTION
### Motivation
- Improve the odds history chart on the team page by plotting the team position after each played game so users can quickly relate odds-area changes to the actual table position progression.
- Reuse already-computed per-game positions (the lower graph) and align each point to the correct stacked odds band so the overlay visually corresponds to the odds area beneath it.

### Description
- Extend the odds-history JSON metadata in `generate_odds_history_json` to include `game_id` for each snapshot point and add an explicit `position` attribute to each stacked series so the frontend can correlate games to snapshots (`app/controllers/championship_controller.rb`).
- Add `buildGamePositionSeries` JavaScript in `app/views/championship/team.html.erb` to build an overlay series named "Position after each game" that finds the first snapshot for each game and plots a point at the vertical midpoint of the corresponding stacked odds band (computed as offset + half of that position's odds).
- Append the overlay series to the odds-history plot and update the hover tooltip logic so the overlay shows a position label (e.g. `2º`) while existing area series continue to show percentage and zone breakdown.

### Testing
- Ran `bin/rails test test/functional/championship_controller_test.rb` but it failed to start due to missing Bundler git dependency in this environment (error: run `bundle install` to fetch git-sourced gems).
- Attempted to capture a page screenshot with Playwright to visually validate the chart, but the local app server was not running (`ERR_EMPTY_RESPONSE`).
- No automated test failures introduced by code edits; environment prevented full test-suite execution here (`bundle install` and a running app server required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd0da950c8330a077843d10988d7b)