### PR TITLE
Add foreign key from player_games.game_id to games with cascade delete

### DIFF
--- a/db/migrate/20260224000000_add_player_games_game_fk.rb
+++ b/db/migrate/20260224000000_add_player_games_game_fk.rb
@@ -1,0 +1,20 @@
+class AddPlayerGamesGameFk < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      DELETE pg
+      FROM player_games pg
+      LEFT JOIN games g ON g.id = pg.game_id
+      WHERE g.id IS NULL
+    SQL
+
+    change_column_default :player_games, :game_id, from: 0, to: nil
+
+    add_foreign_key :player_games, :games, column: :game_id, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :player_games, column: :game_id
+
+    change_column_default :player_games, :game_id, from: nil, to: 0
+  end
+end


### PR DESCRIPTION
### Motivation
- Enforce referential integrity between `player_games` and `games` by removing orphaned `player_games` rows and adding a foreign key with cascade delete.

### Description
- Add `AddPlayerGamesGameFk` migration that deletes orphaned `player_games` via a SQL `DELETE ... LEFT JOIN`, changes the default of `player_games.game_id` from `0` to `nil`, and adds a foreign key to `games` with `on_delete: :cascade`, with a `down` that removes the foreign key and restores the default.

### Testing
- Ran the migration with `bin/rails db:migrate` and executed the test suite with `bundle exec rspec`, and the automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cffaa47ac83309c7a5e01d9605544)