### PR TITLE
Improve SofaScore parsing for incident times, extra time and scores

### DIFF
--- a/lib/scrape.rb
+++ b/lib/scrape.rb
@@ -440,21 +440,18 @@ def parse_match(phase, data, match, rounds, create_groups = false, refetch = fal
     g.round = round
     g.home_score = 0
     g.away_score = 0
+    g.home_aet = nil
+    g.away_aet = nil
+    g.home_pen = nil
+    g.away_pen = nil
 
-    home_score = match["homeScore"]
-    away_score = match["awayScore"]
-    if home_score
-      g.home_score = home_score["display"].to_i
-      g.away_score = away_score["display"].to_i
-      if home_score["EXTRA_TIME"]
-        g.home_aet = home_score["EXTRA_TIME"].to_i - home_score["FINAL_RESULT"].to_i
-        g.away_aet = away_score["EXTRA_TIME"].to_i - away_score["FINAL_RESULT"].to_i
-      end
-      if home_score["penalties"]
-        g.home_pen = home_score["penalties"]
-        g.away_pen = away_score["penalties"]
-      end
-    end
+    score_data = extract_sofascore_scores(match["homeScore"], match["awayScore"])
+    g.home_score = score_data[:full_time_home] || score_data[:final_home] || 0
+    g.away_score = score_data[:full_time_away] || score_data[:final_away] || 0
+    g.home_aet = score_data[:aet_home]
+    g.away_aet = score_data[:aet_away]
+    g.home_pen = score_data[:pen_home]
+    g.away_pen = score_data[:pen_away]
     g.played = match["status"]["type"] == "finished"
     if g.diff(game_compare).size > 0
       Rails.logger.info g.inspect
@@ -489,10 +486,7 @@ def get_scorers(game, lineup_url, incidents_url)
   off = 0
   incidents["incidents"].each do |s|
     if s["incidentType"] == "period" and s["time"] < 999
-      minute = s["time"]
-      if not minute
-        minute = s["timeSeconds"] / 60 + 1
-      end
+      minute = incident_minute(s)
       off = [off, minute].max
       off = [120, off].min
     end
@@ -525,10 +519,7 @@ def get_scorers(game, lineup_url, incidents_url)
 
   fuzzy_match = FuzzyTeamMatch.new
   incidents["incidents"].each do |s|
-    minute = s["time"]
-    if not minute and s["timeSeconds"]
-      minute = s["timeSeconds"] / 60 + 1
-    end
+    minute = incident_minute(s)
     if s["incidentType"] == "goal" and s["incidentClass"] == "regular" and not s["player"].nil?
       player = players[s["player"]["id"]]
       if player.nil? and not missing_player
@@ -536,7 +527,7 @@ def get_scorers(game, lineup_url, incidents_url)
         player = players_by_name[s["pos"]][best_match]
         Rails.logger.info "#{s["pl_name"]} - #{best_match}"
       end
-      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: false, own_goal: false, aet: minute > 90).save! if player
+      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: false, own_goal: false, aet: incident_extra_time?(s)).save! if player
     end
     if s["incidentType"] == "goal" and s["incidentClass"] == "penalty" and not s["player"].nil?
       player = players[s["player"]["id"]]
@@ -545,7 +536,7 @@ def get_scorers(game, lineup_url, incidents_url)
         player = players_by_name[s["pos"]][best_match]
         Rails.logger.info "#{s["pl_name"]} - #{best_match}"
       end
-      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: true, own_goal: false, aet: minute > 90).save! if player
+      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: true, own_goal: false, aet: incident_extra_time?(s)).save! if player
     end
     if s["incidentType"] == "goal" and s["incidentClass"] == "ownGoal"
       player = players[s["player"]["id"]]
@@ -554,7 +545,7 @@ def get_scorers(game, lineup_url, incidents_url)
         player = players_by_name[1 - s["pos"]][best_match]
         Rails.logger.info "#{s["pl_name"]} - #{best_match}"
       end
-      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: false, own_goal: true, aet: minute > 90).save! if player
+      Goal.new(player_id: player.player_id, game_id: game.id, team_id: player.team_id, time: minute, penalty: false, own_goal: true, aet: incident_extra_time?(s)).save! if player
     end
     if s["incidentType"] == "card" and s["incidentClass"] == "yellow"
       # May be a coach
@@ -594,6 +585,57 @@ def get_scorers(game, lineup_url, incidents_url)
   players.values.each do |p|
     p.save!
   end
+end
+
+def incident_minute(incident)
+  minute = incident["time"]
+  if not minute and incident["timeSeconds"]
+    minute = incident["timeSeconds"] / 60 + 1
+  end
+  minute || 0
+end
+
+def incident_extra_time?(incident)
+  incident_minute(incident) > 90
+end
+
+def extract_sofascore_scores(home_score, away_score)
+  full_time_home = score_value(home_score, ["normaltime", "NORMAL_TIME", "FINAL_RESULT", "finalResult"])
+  full_time_away = score_value(away_score, ["normaltime", "NORMAL_TIME", "FINAL_RESULT", "finalResult"])
+
+  extra_total_home = score_value(home_score, ["afterExtraTime", "extraTime", "EXTRA_TIME", "overtime", "OVER_TIME"])
+  extra_total_away = score_value(away_score, ["afterExtraTime", "extraTime", "EXTRA_TIME", "overtime", "OVER_TIME"])
+
+  final_home = score_value(home_score, ["current", "display"])
+  final_away = score_value(away_score, ["current", "display"])
+
+  aet_home = nil
+  aet_away = nil
+  if !full_time_home.nil? && !full_time_away.nil? && !extra_total_home.nil? && !extra_total_away.nil?
+    aet_home = [extra_total_home - full_time_home, 0].max
+    aet_away = [extra_total_away - full_time_away, 0].max
+  end
+
+  {
+    full_time_home: full_time_home,
+    full_time_away: full_time_away,
+    final_home: final_home,
+    final_away: final_away,
+    aet_home: aet_home,
+    aet_away: aet_away,
+    pen_home: score_value(home_score, ["penalties", "PENALTIES"]),
+    pen_away: score_value(away_score, ["penalties", "PENALTIES"]),
+  }
+end
+
+def score_value(score, keys)
+  return nil unless score
+
+  keys.each do |key|
+    value = score[key]
+    return value.to_i unless value.nil?
+  end
+  nil
 end
 
 def process_player(s, game, team_id, end_of_match, starter)

--- a/test/unit/scrape_incident_time_test.rb
+++ b/test/unit/scrape_incident_time_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "scrape"
+
+class ScrapeIncidentTimeTest < ActiveSupport::TestCase
+  test "incident_minute ignores added time" do
+    incident = { "time" => 90, "addedTime" => 3 }
+
+    assert_equal 90, incident_minute(incident)
+  end
+
+  test "incident_extra_time does not treat second half stoppage as aet" do
+    incident = { "time" => 90, "addedTime" => 4 }
+
+    assert_not incident_extra_time?(incident)
+  end
+
+  test "incident_extra_time does not treat first half stoppage as aet" do
+    incident = { "time" => 45, "addedTime" => 5 }
+
+    assert_equal 45, incident_minute(incident)
+    assert_not incident_extra_time?(incident)
+  end
+
+  test "incident_extra_time marks extra time periods" do
+    incident = { "time" => 105, "addedTime" => 1 }
+
+    assert incident_extra_time?(incident)
+    assert_equal 105, incident_minute(incident)
+  end
+  test "incident_minute uses timeSeconds fallback" do
+    incident = { "timeSeconds" => 59 * 60 }
+
+    assert_equal 60, incident_minute(incident)
+  end
+
+  test "incident_extra_time uses timeSeconds fallback for extra time detection" do
+    incident = { "timeSeconds" => 91 * 60 }
+
+    assert_equal 92, incident_minute(incident)
+    assert incident_extra_time?(incident)
+  end
+
+end

--- a/test/unit/scrape_score_parsing_test.rb
+++ b/test/unit/scrape_score_parsing_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "scrape"
+
+class ScrapeScoreParsingTest < ActiveSupport::TestCase
+  test "extract_sofascore_scores prefers full-time score and captures extra-time goals" do
+    home_score = { "current" => 3, "display" => 3, "normaltime" => 2, "afterExtraTime" => 3 }
+    away_score = { "current" => 2, "display" => 2, "normaltime" => 2, "afterExtraTime" => 2 }
+
+    scores = extract_sofascore_scores(home_score, away_score)
+
+    assert_equal 2, scores[:full_time_home]
+    assert_equal 2, scores[:full_time_away]
+    assert_equal 1, scores[:aet_home]
+    assert_equal 0, scores[:aet_away]
+    assert_equal 3, scores[:final_home]
+    assert_equal 2, scores[:final_away]
+  end
+
+  test "extract_sofascore_scores captures penalties when present" do
+    home_score = { "current" => 1, "display" => 1, "normaltime" => 1, "penalties" => 4 }
+    away_score = { "current" => 1, "display" => 1, "normaltime" => 1, "penalties" => 3 }
+
+    scores = extract_sofascore_scores(home_score, away_score)
+
+    assert_equal 4, scores[:pen_home]
+    assert_equal 3, scores[:pen_away]
+  end
+
+  test "extract_sofascore_scores falls back to final score when full-time is missing" do
+    home_score = { "display" => "2" }
+    away_score = { "display" => "1" }
+
+    scores = extract_sofascore_scores(home_score, away_score)
+
+    assert_nil scores[:full_time_home]
+    assert_nil scores[:full_time_away]
+    assert_equal 2, scores[:final_home]
+    assert_equal 1, scores[:final_away]
+    assert_nil scores[:aet_home]
+    assert_nil scores[:aet_away]
+  end
+end


### PR DESCRIPTION
### Motivation
- Make parsing of incident times and match scores from SofaScore more robust against differing JSON shapes and missing fields.
- Ensure extra-time and penalty information is detected consistently for goal events and stored on `Game` and `Goal` records.

### Description
- Add helper functions `incident_minute`, `incident_extra_time?`, `extract_sofascore_scores`, and `score_value` to centralize time and score extraction logic.
- Replace ad-hoc inline time calculations with `incident_minute` and replace `minute > 90` checks with `incident_extra_time?` when creating `Goal` records.
- Replace previous score extraction with `extract_sofascore_scores` and initialize `g.home_aet`, `g.away_aet`, `g.home_pen`, and `g.away_pen` before assigning parsed values.
- Keep backward-compatible fallbacks for different SofaScore key names and use `timeSeconds` as a fallback for incident minutes.

### Testing
- Added unit tests `test/unit/scrape_incident_time_test.rb` and `test/unit/scrape_score_parsing_test.rb` covering `incident_minute`, `incident_extra_time?`, and `extract_sofascore_scores` behaviors. 
- Ran the Rails unit test suite with `rails test` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7afff28883308ad95ef55a6960b7)