### PR TITLE
Fix extra-time detection in `get_scorers` and safely iterate incidents

### DIFF
--- a/lib/scrape.rb
+++ b/lib/scrape.rb
@@ -478,13 +478,25 @@ def get_scorers(game, lineup_url, incidents_url)
     return
   end
   incidents = ChampionshipGet.get(incidents_url)
+  incidents_list = incidents["incidents"] || []
+
+  has_extra_time_period = incidents_list.any? do |incident|
+    incident["incidentType"] == "period" and incident["time"].to_i < 999 and incident_minute(incident) > 90
+  end
+
+  if not has_extra_time_period
+    game.home_aet = nil
+    game.away_aet = nil
+    game.save! if game.changed?
+  end
+
   game.goals.clear
   game.player_games.clear
   players = {}
   players_by_name = { 0 => {}, 1 => {} }
   players_by_id = {}
   off = 0
-  incidents["incidents"].each do |s|
+  incidents_list.each do |s|
     if s["incidentType"] == "period" and s["time"] < 999
       minute = incident_minute(s)
       off = [off, minute].max
@@ -518,7 +530,7 @@ def get_scorers(game, lineup_url, incidents_url)
   end
 
   fuzzy_match = FuzzyTeamMatch.new
-  incidents["incidents"].each do |s|
+  incidents_list.each do |s|
     minute = incident_minute(s)
     if s["incidentType"] == "goal" and s["incidentClass"] == "regular" and not s["player"].nil?
       player = players[s["player"]["id"]]


### PR DESCRIPTION
### Motivation
- Prevent stale extra-time flags on `game` when the incidents payload contains no extra-time period and guard against missing `incidents` data.

### Description
- Add `incidents_list = incidents["incidents"] || []` and replace direct uses of `incidents["incidents"]` with `incidents_list` to avoid `nil` errors.
- Detect extra-time presence with `has_extra_time_period` using `incident_minute(incident) > 90` and clear `game.home_aet`/`game.away_aet` when no extra-time period is present, saving the `game` if it changed.
- Use `incident["time"].to_i` when checking time bounds to make the check robust against non-integer values, while keeping the existing logic that computes `off` and creates `Goal` records.

### Testing
- Ran the automated test suite with `bundle exec rspec` and relevant specs; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdeb210588330af7dfbcd03ad4461)