### PR TITLE
Fix extra-time goal parsing for SofaScore overtime fields

### DIFF
--- a/lib/scrape.rb
+++ b/lib/scrape.rb
@@ -621,12 +621,8 @@ def extract_sofascore_scores(home_score, away_score)
   final_home = score_value(home_score, ["current", "display"])
   final_away = score_value(away_score, ["current", "display"])
 
-  aet_home = nil
-  aet_away = nil
-  if !full_time_home.nil? && !full_time_away.nil? && !extra_total_home.nil? && !extra_total_away.nil?
-    aet_home = [extra_total_home - full_time_home, 0].max
-    aet_away = [extra_total_away - full_time_away, 0].max
-  end
+  aet_home = extract_aet_goals(home_score, full_time_home, final_home, extra_total_home)
+  aet_away = extract_aet_goals(away_score, full_time_away, final_away, extra_total_away)
 
   {
     full_time_home: full_time_home,
@@ -638,6 +634,31 @@ def extract_sofascore_scores(home_score, away_score)
     pen_home: score_value(home_score, ["penalties", "PENALTIES"]),
     pen_away: score_value(away_score, ["penalties", "PENALTIES"]),
   }
+end
+
+def extract_aet_goals(score, full_time, final_score, extra_total)
+  period_extra_goals = score_sum(score, ["extra1", "extra2"])
+  return period_extra_goals unless period_extra_goals.nil?
+
+  return nil if full_time.nil? || extra_total.nil?
+
+  extra_goal_delta = extra_total - full_time
+  return extra_goal_delta if extra_goal_delta > 0
+
+  if !final_score.nil? && full_time + extra_total == final_score
+    return extra_total
+  end
+
+  [extra_goal_delta, 0].max
+end
+
+def score_sum(score, keys)
+  return nil unless score
+
+  values = keys.map { |key| score[key] }.compact
+  return nil if values.empty?
+
+  values.sum { |value| value.to_i }
 end
 
 def score_value(score, keys)

--- a/test/unit/scrape_score_parsing_test.rb
+++ b/test/unit/scrape_score_parsing_test.rb
@@ -39,4 +39,14 @@ class ScrapeScoreParsingTest < ActiveSupport::TestCase
     assert_nil scores[:aet_home]
     assert_nil scores[:aet_away]
   end
+
+  test "extract_sofascore_scores handles overtime as extra-time-only goals" do
+    home_score = { "current" => 0, "display" => 0, "normaltime" => 0, "overtime" => 0, "extra1" => 0, "extra2" => 0 }
+    away_score = { "current" => 2, "display" => 2, "normaltime" => 1, "overtime" => 1, "extra1" => 1, "extra2" => 0 }
+
+    scores = extract_sofascore_scores(home_score, away_score)
+
+    assert_equal 0, scores[:aet_home]
+    assert_equal 1, scores[:aet_away]
+  end
 end


### PR DESCRIPTION
### Motivation
- SofaScore sometimes reports extra-time as per-period fields (`extra1`/`extra2`) or uses `overtime` as “goals scored in extra time” rather than a post-ET total, and the old parser treated these fields as totals causing incorrect `aet` values.
- The specific symptom was `awayScore.overtime = 1` plus `normaltime = 1` and `current = 2` producing `aet_away = 0` instead of `1`.

### Description
- Replace the previous inline subtraction logic in `extract_sofascore_scores` with a dedicated helper `extract_aet_goals` that encapsulates AET extraction rules.
- Prefer explicit period sums by adding `score_sum(score, ["extra1","extra2"])` and return that when present.
- Keep legacy fallback behavior using `afterExtraTime/extraTime/overtime` totals but detect and handle the shape where `overtime` represents ET-only goals by checking `full_time + extra_total == final`.
- Add a unit test `test "extract_sofascore_scores handles overtime as extra-time-only goals"` in `test/unit/scrape_score_parsing_test.rb` that reproduces the problematic payload and asserts the correct `aet` values.

### Testing
- Added `test/unit/scrape_score_parsing_test.rb` case exercising `normaltime: 1`, `overtime: 1`, `current: 2` and verifying `aet_away == 1` and `aet_home == 0`.
- Attempted to run `bin/rails test test/unit/scrape_score_parsing_test.rb` but the environment failed to start the test run because Bundler reports a missing git-sourced dependency (`capistrano/rbenv`) and asks to run `bundle install` first, so tests could not be executed here.
- Static inspection and local test addition were performed and the new logic is covered by the added test which should pass once dependencies are installed and the test suite is run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b84f09088330b6d1588f475eedee)