### PR TITLE
Load team geolocation static map via JavaScript

### DIFF
--- a/app/views/team/_geolocation.html.erb
+++ b/app/views/team/_geolocation.html.erb
@@ -54,6 +54,7 @@ path = ""
 if show_path then
   path = "&path=color:0xff0000|weight:5|geodesic:true|#{points.map{|p|"#{p[:geometry][:coordinates][1]},#{p[:geometry][:coordinates][0]}"}.join("|")}"
 end
+static_map_url = GoogleUrlSigner.sign("https://maps.googleapis.com/maps/api/staticmap?#{markers}#{path}&zoom=#{maxzoom}&#{"region=br&language=pt&" if I18n.locale == :"pt-BR" }size=560x400&scale=2&format=jpg&key=AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE", Rails.application.credentials.google_api[:secret_sign])
 %>
 <script src="https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js"></script>
 <style>
@@ -197,7 +198,7 @@ $(function() {
     const staticMap = $('#static_map');
     if (staticMap.attr('src')) return;
 
-    staticMap.attr('src', '<%= j(GoogleUrlSigner.sign("https://maps.googleapis.com/maps/api/staticmap?#{markers}#{path}&zoom=#{maxzoom}&#{"region=br&language=pt&" if I18n.locale == :"pt-BR" }size=560x400&scale=2&format=jpg&key=AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE", Rails.application.credentials.google_api[:secret_sign])) %>');
+    staticMap.attr('src', <%= raw static_map_url.to_json %>);
   }
 
   async function start() {

--- a/app/views/team/_geolocation.html.erb
+++ b/app/views/team/_geolocation.html.erb
@@ -193,10 +193,20 @@ function initMap() {
   });
 
 $(function() {
+  function loadStaticMapImage() {
+    const staticMap = $('#static_map');
+    if (staticMap.attr('src')) return;
+
+    staticMap.attr('src', '<%= j(GoogleUrlSigner.sign("https://maps.googleapis.com/maps/api/staticmap?#{markers}#{path}&zoom=#{maxzoom}&#{"region=br&language=pt&" if I18n.locale == :"pt-BR" }size=560x400&scale=2&format=jpg&key=AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE", Rails.application.credentials.google_api[:secret_sign])) %>');
+  }
+
   async function start() {
     const { Map } = await google.maps.importLibrary("maps");
     initMap(Map);
   }
+
+  loadStaticMapImage();
+
   $('#static_map').on("click", async function() {
     await start();
     $('#static_map').hide();
@@ -204,6 +214,6 @@ $(function() {
 });
 
 </script>
-<img id=static_map width=560 height=400 src="<%= GoogleUrlSigner.sign "https://maps.googleapis.com/maps/api/staticmap?#{markers}#{path}&zoom=#{maxzoom}&#{"region=br&language=pt&" if I18n.locale == :"pt-BR" }size=560x400&scale=2&format=jpg&key=AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE", Rails.application.credentials.google_api[:secret_sign] %>" />
+<img id=static_map width=560 height=400 />
 
 </div>


### PR DESCRIPTION
### Motivation
- Prevent non-JS bots from fetching Google Static Maps by avoiding a direct `src` URL in the HTML and loading the signed static-map URL from JavaScript at runtime.

### Description
- Updated `app/views/team/_geolocation.html.erb` to render the static map `<img id="static_map">` without a `src` and added a `loadStaticMapImage` JavaScript helper that assigns the existing signed static-map URL to the `src` at runtime, preserving the existing click-to-replace behavior that initializes the interactive Google Map.

### Testing
- Ran `bin/rails test test/functional/team_controller_test.rb` which passed (1 run, 1 assertion, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35ef31b1883308d4035a094ecfe89)