### PR TITLE
Reject map static requests without referrer

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -4,6 +4,7 @@ require 'google_url_signer'
 
 class MapController < ApplicationController
   skip_authorization_check
+  before_action :require_referrer!, only: :static
   GOOGLE_STATIC_MAPS_API_KEY = 'AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE'
 
   def static
@@ -42,6 +43,12 @@ class MapController < ApplicationController
   end
 
   private
+
+  def require_referrer!
+    return if request.referrer.present?
+
+    head :forbidden
+  end
 
   def log_static_map_warnings(response)
     warning_header = response['X-Staticmap-API-Warning']

--- a/test/functional/map_controller_test.rb
+++ b/test/functional/map_controller_test.rb
@@ -1,0 +1,19 @@
+require File.dirname(__FILE__) + '/../test_helper'
+require 'map_controller'
+
+# Re-raise errors caught by the controller.
+class MapController; def rescue_action(e) raise e end; end
+
+class MapControllerTest < ActionController::TestCase
+  def setup
+    @controller = MapController.new
+    @request    = ActionController::TestRequest.new
+    @response   = ActionController::TestResponse.new
+  end
+
+  def test_static_rejects_request_without_referrer
+    get :static
+
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
### Motivation
- Ensure the `map#static` endpoint rejects direct requests that lack a referrer to prevent unauthorized or hotlinked access.

### Description
- Add a `before_action :require_referrer!, only: :static` and implement `require_referrer!` in `app/controllers/map_controller.rb` to return `head :forbidden` when `request.referrer` is blank, and add a functional test `test/functional/map_controller_test.rb` verifying the behavior.

### Testing
- Ran `bin/rails test test/functional/map_controller_test.rb` which passed (1 run, 1 assertion, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a516bd07a88330ba58dd661e51e8ed)