### PR TITLE
Limit hourly game scrape to recent-start phases

### DIFF
--- a/app/services/game_data_scrape_service.rb
+++ b/app/services/game_data_scrape_service.rb
@@ -4,7 +4,7 @@ class GameDataScrapeService
   LOCK_PATH = Rails.root.join("tmp", "game_data_scrape.lock")
   MAX_CONCURRENCY = 3
 
-  def self.start_async(refetch: false)
+  def self.start_async(refetch: false, include_all_past_unplayed: false)
     lock_file = File.open(LOCK_PATH, "w")
     unless lock_file.flock(File::LOCK_EX | File::LOCK_NB)
       lock_file.close
@@ -14,7 +14,7 @@ class GameDataScrapeService
     Thread.new do
       ActiveRecord::Base.connection_pool.with_connection do
         begin
-          run_unlocked(refetch: refetch)
+          run_unlocked(refetch: refetch, include_all_past_unplayed: include_all_past_unplayed)
         ensure
           lock_file.flock(File::LOCK_UN) rescue nil
           lock_file.close rescue nil
@@ -25,7 +25,7 @@ class GameDataScrapeService
     :started
   end
 
-  def self.run(refetch: false)
+  def self.run(refetch: false, include_all_past_unplayed: false)
     lock_file = File.open(LOCK_PATH, "w")
     unless lock_file.flock(File::LOCK_EX | File::LOCK_NB)
       lock_file.close
@@ -33,20 +33,23 @@ class GameDataScrapeService
     end
 
     begin
-      run_unlocked(refetch: refetch)
+      run_unlocked(refetch: refetch, include_all_past_unplayed: include_all_past_unplayed)
     ensure
       lock_file.flock(File::LOCK_UN) rescue nil
       lock_file.close rescue nil
     end
   end
 
-  def self.phases_to_scrape
+  def self.phases_to_scrape(include_all_past_unplayed: false)
+    pending_games_scope = Game.where(played: false).where("date < ?", Time.now)
+    pending_games_scope = pending_games_scope.where("date >= ?", 5.hours.ago) unless include_all_past_unplayed
+
     Phase
       .joins(:championship)
+      .joins("INNER JOIN (#{pending_games_scope.select(:phase_id).distinct.to_sql}) pending_phase_games ON pending_phase_games.phase_id = phases.id")
       .where.not(scrape_url: [nil, ""])
       .where("championships.end >= ?", Date.today - 30.days)
       .distinct
-      .select { |phase| phase.games.where(played: false).where("date < ?", Time.now).exists? }
   end
 
   def self.scrape_phase(phase, rounds: nil, refetch: false)
@@ -69,9 +72,10 @@ class GameDataScrapeService
     :started
   end
 
-  def self.run_unlocked(refetch: false)
-    phases = phases_to_scrape
-    Rails.logger.info "Found #{phases.size} phase(s) with pending games to scrape (refetch=#{refetch})"
+  def self.run_unlocked(refetch: false, include_all_past_unplayed: false)
+    phases = phases_to_scrape(include_all_past_unplayed: include_all_past_unplayed)
+    window_description = include_all_past_unplayed ? "all past pending games" : "pending games from last 5 hours"
+    Rails.logger.info "Found #{phases.size} phase(s) with #{window_description} to scrape (refetch=#{refetch})"
 
     queue = Queue.new
     phases.each { |phase| queue << phase }

--- a/lib/rufus_scheduler_runner.rb
+++ b/lib/rufus_scheduler_runner.rb
@@ -6,8 +6,9 @@ class RufusSchedulerRunner
   def start
     scheduler.every '1h', first_in: '0s' do
       refetch = Time.current.hour == 3
-      Rails.logger.info "[scheduler] Starting periodic game data scrape (refetch=#{refetch})"
-      result = GameDataScrapeService.start_async(refetch: refetch)
+      include_all_past_unplayed = Time.current.hour == 3
+      Rails.logger.info "[scheduler] Starting periodic game data scrape (refetch=#{refetch}, include_all_past_unplayed=#{include_all_past_unplayed})"
+      result = GameDataScrapeService.start_async(refetch: refetch, include_all_past_unplayed: include_all_past_unplayed)
       Rails.logger.info "[scheduler] Game data scrape result: #{result}"
     end
 

--- a/lib/tasks/game_scrape.rake
+++ b/lib/tasks/game_scrape.rake
@@ -1,14 +1,16 @@
 namespace :game_scrape do
-  desc "Scrape game data for phases with pending games. Usage: rake game_scrape:run [REFETCH=true]"
+  desc "Scrape game data for phases with pending games. Usage: rake game_scrape:run [REFETCH=true] [ALL_PAST_PENDING=true]"
   task run: :environment do
     refetch = ENV["REFETCH"].to_s == "true"
-    GameDataScrapeService.run(refetch: refetch)
+    include_all_past_unplayed = ENV["ALL_PAST_PENDING"].to_s == "true"
+    GameDataScrapeService.run(refetch: refetch, include_all_past_unplayed: include_all_past_unplayed)
   end
 
-  desc "Start game data scraping in a background thread (non-blocking). Usage: rake game_scrape:start_async [REFETCH=true]"
+  desc "Start game data scraping in a background thread (non-blocking). Usage: rake game_scrape:start_async [REFETCH=true] [ALL_PAST_PENDING=true]"
   task start_async: :environment do
     refetch = ENV["REFETCH"].to_s == "true"
-    result = GameDataScrapeService.start_async(refetch: refetch)
+    include_all_past_unplayed = ENV["ALL_PAST_PENDING"].to_s == "true"
+    result = GameDataScrapeService.start_async(refetch: refetch, include_all_past_unplayed: include_all_past_unplayed)
     case result
     when :started
       puts "Game data scrape started in background"

--- a/test/unit/game_data_scrape_service_test.rb
+++ b/test/unit/game_data_scrape_service_test.rb
@@ -2,20 +2,6 @@ require "test_helper"
 require "scrape"
 
 class GameDataScrapeServiceTest < ActiveSupport::TestCase
-  class FakePendingGames
-    def initialize(has_pending)
-      @has_pending = has_pending
-    end
-
-    def where(*_args)
-      self
-    end
-
-    def exists?
-      @has_pending
-    end
-  end
-
   class FakePhase
     attr_reader :id, :name, :scrape_url, :scraped
 
@@ -25,10 +11,6 @@ class GameDataScrapeServiceTest < ActiveSupport::TestCase
       @scrape_url = scrape_url
       @has_pending_games = has_pending_games
       @scraped = false
-    end
-
-    def games
-      FakePendingGames.new(@has_pending_games)
     end
 
     def mark_scraped!
@@ -58,19 +40,50 @@ class GameDataScrapeServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "phases_to_scrape returns only phases with scrape_url and pending games" do
-    with_pending = FakePhase.new(id: 1, name: "Group Stage", scrape_url: "http://sofascore.com/api/v1/events/round/", has_pending_games: true)
-    no_pending = FakePhase.new(id: 2, name: "Knockout", scrape_url: "http://sofascore.com/api/v1/events/round/", has_pending_games: false)
+  test "phases_to_scrape applies the recent pending games window by default" do
+    where_calls = []
+    fake_pending_scope = Object.new
+    fake_pending_scope.define_singleton_method(:where) do |sql, value|
+      where_calls << [sql, value]
+      self
+    end
+    fake_pending_scope.define_singleton_method(:select) { |_field| self }
+    fake_pending_scope.define_singleton_method(:distinct) { self }
+    fake_pending_scope.define_singleton_method(:to_sql) { "SELECT DISTINCT phase_id FROM games" }
 
-    phases = [with_pending, no_pending]
-    fake_relation = FakePhaseRelation.new(phases)
+    fake_relation = FakePhaseRelation.new([])
 
-    result = Phase.stub(:joins, fake_relation) do
-      GameDataScrapeService.phases_to_scrape
+    Game.stub(:where, fake_pending_scope) do
+      Phase.stub(:joins, fake_relation) do
+        GameDataScrapeService.phases_to_scrape
+      end
     end
 
-    assert_includes result, with_pending
-    refute_includes result, no_pending
+    assert where_calls.any? { |sql, _| sql.include?("date < ?") }
+    assert where_calls.any? { |sql, _| sql.include?("date >= ?") }
+  end
+
+  test "phases_to_scrape can include all past pending games" do
+    where_calls = []
+    fake_pending_scope = Object.new
+    fake_pending_scope.define_singleton_method(:where) do |sql, value|
+      where_calls << [sql, value]
+      self
+    end
+    fake_pending_scope.define_singleton_method(:select) { |_field| self }
+    fake_pending_scope.define_singleton_method(:distinct) { self }
+    fake_pending_scope.define_singleton_method(:to_sql) { "SELECT DISTINCT phase_id FROM games" }
+
+    fake_relation = FakePhaseRelation.new([])
+
+    Game.stub(:where, fake_pending_scope) do
+      Phase.stub(:joins, fake_relation) do
+        GameDataScrapeService.phases_to_scrape(include_all_past_unplayed: true)
+      end
+    end
+
+    assert where_calls.any? { |sql, _| sql.include?("date < ?") }
+    refute where_calls.any? { |sql, _| sql.include?("date >= ?") }
   end
 
   test "run_unlocked calls scrape for each phase with pending games" do


### PR DESCRIPTION
### Motivation
- Reduce unnecessary hourly scraping by only attempting phases that have unplayed games which started in the last 5 hours, while still providing a daily catch-up that covers all past unplayed games.
- Keep scheduler-driven behavior configurable and safe for backfills without changing external scrape JSON shapes or other services.

### Description
- Add an `include_all_past_unplayed` flag threaded through `GameDataScrapeService.start_async`, `GameDataScrapeService.run`, and `GameDataScrapeService.run_unlocked` to select the scrape window.
- Replace the Ruby-side phase filtering with a SQL join against a `pending_games_scope` that is restricted to `date >= 5.hours.ago` by default and relaxed when `include_all_past_unplayed: true`, implemented in `GameDataScrapeService.phases_to_scrape`.
- Update the hourly scheduler in `lib/rufus_scheduler_runner.rb` to enable the broader daily catch-up mode at 03:00 by passing `include_all_past_unplayed: true` when appropriate.
- Update `lib/tasks/game_scrape.rake` to accept `ALL_PAST_PENDING=true` and wire it to the new flag for both blocking (`rake game_scrape:run`) and async (`rake game_scrape:start_async`) tasks.
- Add/adjust unit tests in `test/unit/game_data_scrape_service_test.rb` to verify the default 5-hour window and the `include_all_past_unplayed` behavior.

### Testing
- Ran the targeted unit tests with `bin/rails test test/unit/game_data_scrape_service_test.rb` and they passed (`7 runs, 15 assertions, 0 failures`).
- Verified the changed code paths exercise the new `include_all_past_unplayed` flag via updated tests that assert the presence/absence of the `date >= ?` constraint in the generated queries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61069274083309758c4bf0c524702)