### PR TITLE
Validate map/static requests using explicit referrer parameter

### DIFF
--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -4,7 +4,7 @@ require 'google_url_signer'
 
 class MapController < ApplicationController
   skip_authorization_check
-  before_action :require_referrer!, only: :static
+  before_action :require_matching_referrer!, only: :static
   GOOGLE_STATIC_MAPS_API_KEY = 'AIzaSyCT_RQIGXyWC6LEKwGVkiIAyXJjWfuKJkE'
 
   def static
@@ -44,8 +44,10 @@ class MapController < ApplicationController
 
   private
 
-  def require_referrer!
-    return if request.referrer.present?
+  def require_matching_referrer!
+    request_referrer = request.referrer.to_s
+    param_referrer = params[:referrer].to_s
+    return if request_referrer.present? && param_referrer.present? && request_referrer == param_referrer
 
     head :forbidden
   end

--- a/app/views/team/_geolocation.html.erb
+++ b/app/views/team/_geolocation.html.erb
@@ -60,7 +60,8 @@ static_map_params = {
   zoom: maxzoom,
   size: "560x400",
   scale: "2",
-  format: "jpg"
+  format: "jpg",
+  referrer: request.original_url
 }
 
 if I18n.locale == :"pt-BR"

--- a/test/functional/map_controller_test.rb
+++ b/test/functional/map_controller_test.rb
@@ -16,4 +16,34 @@ class MapControllerTest < ActionController::TestCase
 
     assert_response :forbidden
   end
+
+  def test_static_rejects_request_with_mismatched_referrer
+    @request.env['HTTP_REFERER'] = 'http://test.host/team/show/1'
+
+    @request.env['QUERY_STRING'] = 'referrer=http%3A%2F%2Ftest.host%2Fteam%2Fshow%2F2'
+    get :static
+
+    assert_response :forbidden
+  end
+
+  def test_static_accepts_request_with_matching_referrer
+    @request.env['HTTP_REFERER'] = 'http://test.host/team/show/1'
+    fake_response = Net::HTTPOK.new('1.1', '200', 'OK')
+    fake_response['content-type'] = 'image/jpeg'
+    fake_response.instance_variable_set(:@read, true)
+    fake_response.body = 'jpg'
+
+    fake_credentials = Struct.new(:google_api).new({ secret_sign: 'test-sign' })
+
+    Rails.application.stub(:credentials, fake_credentials) do
+      GoogleUrlSigner.stub(:sign, 'https://maps.googleapis.com/maps/api/staticmap?key=test') do
+        Net::HTTP.stub(:start, fake_response) do
+          @request.env['QUERY_STRING'] = 'referrer=http%3A%2F%2Ftest.host%2Fteam%2Fshow%2F1'
+          get :static
+        end
+      end
+    end
+
+    assert_response :success
+  end
 end


### PR DESCRIPTION
### Motivation
- Prevent unauthorized use of the `map/static` proxy by ensuring the browser `Referer` header matches an explicit `referrer` query parameter before the server requests a signed Google Static Maps image.

### Description
- Replace the simple presence check with strict validation in `MapController#static` by adding `require_matching_referrer!` which only allows the request when `request.referrer` and `params[:referrer]` are both present and equal. (`app/controllers/map_controller.rb`)
- Include the current page URL as the `referrer` parameter when generating `map/static` links in the team geolocation partial by adding `referrer: request.original_url`. (`app/views/team/_geolocation.html.erb`)
- Add functional tests that cover: rejection without referrer, rejection when the query `referrer` mismatches the `Referer` header, and acceptance when both match (external HTTP and signing calls are stubbed). (`test/functional/map_controller_test.rb`)

### Testing
- Ran `bin/rails test test/functional/map_controller_test.rb`, which executed the new map controller tests and passed: `3 runs, 3 assertions, 0 failures, 0 errors`.
- The acceptance test stubs external dependencies (`GoogleUrlSigner` and `Net::HTTP`) and stubs `Rails.application.credentials` to avoid hitting external services during automated testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6bd22315c8330ba49440f4fdcb8c9)