### PR TITLE
Handle missing substitution playerOut with helper functions and tests

### DIFF
--- a/lib/scrape.rb
+++ b/lib/scrape.rb
@@ -585,18 +585,32 @@ def get_scorers(game, lineup_url, incidents_url)
       next if not player
       player.on = minute
       player.off = off
-      player_out = players[s["playerOut"]["id"]]
-      if (player and player_out.nil?) or (player_out.nil? and not missing_player)
-        best_match = players_by_name[s["pos"]].keys.map{|t| [t, fuzzy_match.getDistance(t, s["pl_name_o"])]}.sort{|a,b|b[1] <=> a[1]}[0][0]
-        player_out = players_by_name[s["pos"]][best_match]
-        Rails.logger.info "#{s["pl_name_o"]} - #{best_match}"
+      player_out_id = incident_player_id(s, "playerOut")
+      player_out = player_out_id ? players[player_out_id] : nil
+      player_out_name = incident_player_out_name(s)
+      if player_out.nil? and player_out_name
+        if (player and player_out.nil?) or (player_out.nil? and not missing_player)
+          best_match = players_by_name[s["pos"]].keys.map{|t| [t, fuzzy_match.getDistance(t, player_out_name)]}.sort{|a,b|b[1] <=> a[1]}[0][0]
+          player_out = players_by_name[s["pos"]][best_match]
+          Rails.logger.info "#{player_out_name} - #{best_match}"
+        end
       end
+      next if player_out.nil?
       player_out.off = minute
     end
   end
   players.values.each do |p|
     p.save!
   end
+end
+
+def incident_player_id(incident, key = "player")
+  player = incident[key]
+  player && player["id"]
+end
+
+def incident_player_out_name(incident)
+  incident["pl_name_o"] || incident["playerNameOut"]
 end
 
 def incident_minute(incident)

--- a/test/unit/scrape_incident_time_test.rb
+++ b/test/unit/scrape_incident_time_test.rb
@@ -27,6 +27,7 @@ class ScrapeIncidentTimeTest < ActiveSupport::TestCase
     assert incident_extra_time?(incident)
     assert_equal 105, incident_minute(incident)
   end
+
   test "incident_minute uses timeSeconds fallback" do
     incident = { "timeSeconds" => 59 * 60 }
 
@@ -40,4 +41,27 @@ class ScrapeIncidentTimeTest < ActiveSupport::TestCase
     assert incident_extra_time?(incident)
   end
 
+  test "incident_player_id returns nil when nested player hash is missing" do
+    incident = { "incidentType" => "substitution", "playerIn" => { "id" => 10 } }
+
+    assert_nil incident_player_id(incident, "playerOut")
+  end
+
+  test "incident_player_id returns id when nested player hash exists" do
+    incident = { "playerOut" => { "id" => 42 } }
+
+    assert_equal 42, incident_player_id(incident, "playerOut")
+  end
+
+  test "incident_player_out_name supports legacy pl_name_o" do
+    incident = { "pl_name_o" => "Old Name" }
+
+    assert_equal "Old Name", incident_player_out_name(incident)
+  end
+
+  test "incident_player_out_name supports playerNameOut" do
+    incident = { "playerNameOut" => "New Name" }
+
+    assert_equal "New Name", incident_player_out_name(incident)
+  end
 end


### PR DESCRIPTION
### Motivation
- Substitution incidents sometimes lack a nested `playerOut` hash or use legacy name fields, which caused nil errors and unreliable fuzzy matching. 
- The change aims to robustly extract an outgoing player's id or name and avoid calling methods on nil objects. 
- Add explicit helpers to consolidate incident field lookup and make the substitution logic clearer and safer.

### Description
- Introduced `incident_player_id` and `incident_player_out_name` helper methods to centralize extraction of nested player ids and legacy name fields. 
- Updated substitution handling in `get_scorers` to use `player_out_id = incident_player_id(s, "playerOut")` and `player_out_name = incident_player_out_name(s)` as fallbacks for fuzzy matching. 
- Added a guard `next if player_out.nil?` to avoid calling properties on a nil `player_out`, and updated logging to use the resolved outgoing player name. 
- Kept existing logic for setting `on`/`off` times and fuzzy matching but switched string source to the normalized `player_out_name` when present.

### Testing
- Ran unit tests in `test/unit/scrape_incident_time_test.rb`, including new tests for `incident_player_id` and `incident_player_out_name`, and they passed. 
- Ran the full test suite with `bundle exec rake test` and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d71ddf848330a68a79b5c561de90)