### PR TITLE
Add `required` validation message to en-US and pt-BR locales

### DIFF
--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -119,6 +119,7 @@ en-US:
       not_an_integer: must be an integer
       odd: must be odd
       record_invalid: ! 'Validation failed: %{errors}'
+      required: is required
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -119,6 +119,7 @@ pt-BR:
       not_an_integer: não é um número inteiro
       odd: deve ser ímpar
       record_invalid: ! 'A validação falhou: %{errors}'
+      required: é obrigatório
       taken: já está em uso
       too_long: ! 'é muito longo (máximo: %{count} caracteres)'
       too_short: ! 'é muito curto (mínimo: %{count} caracteres)'


### PR DESCRIPTION
### Motivation
- Add the missing `required` validation message to localization files so forms and model validations can display a consistent "is required" message in English and Portuguese.

### Description
- Inserted the `required` key under `errors.messages` in `config/locales/en-US.yml` with value `is required` and in `config/locales/pt-BR.yml` with value `é obrigatório`.

### Testing
- No automated tests were run as part of this change since it only updates locale YAML files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9297da97c8330b9e73e39acb2c991)