### PR TITLE
Add player merge feature with model logic, controller action, route, view form and tests

### DIFF
--- a/app/controllers/player_controller.rb
+++ b/app/controllers/player_controller.rb
@@ -109,6 +109,20 @@ class PlayerController < ApplicationController
     end
   end
 
+
+  def merge
+    @player = Player.find(params[:id])
+    source_player = Player.find(params[:source_player_id])
+
+    @player.merge_player(source_player)
+
+    flash[:notice] = _("Player was successfully updated")
+    redirect_to :action => :show, :id => @player
+  rescue ActiveRecord::RecordNotFound
+    flash[:notice] = _("Player was not found")
+    redirect_back(fallback_location: { :action => :show, :id => params[:id] })
+  end
+
   def update_rating
     PlayerRatingUpdateService.run
     redirect_back(fallback_location: root_path)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -51,6 +51,7 @@ class Player < ApplicationRecord
       self.position = source_player.position if position.blank?
       self.birth = source_player.birth if birth.blank?
       self.country = source_player.country if country.blank?
+      self.sofascore_id = source_player.sofascore_id if sofascore_id.blank?
       save!
 
       source_player.destroy!

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -40,4 +40,20 @@ class Player < ApplicationRecord
   def small_country_logo
     Player.small_country_flag(country)
   end
+
+  def merge_player(source_player)
+    transaction do
+      Goal.where(player_id: source_player.id).update_all(player_id: id)
+      PlayerGame.where(player_id: source_player.id).update_all(player_id: id)
+      TeamPlayer.where(player_id: source_player.id).update_all(player_id: id)
+
+      self.full_name = [full_name, source_player.full_name].compact.max_by(&:length)
+      self.position = source_player.position if position.blank?
+      self.birth = source_player.birth if birth.blank?
+      self.country = source_player.country if country.blank?
+      save!
+
+      source_player.destroy!
+    end
+  end
 end

--- a/app/views/player/show.html.erb
+++ b/app/views/player/show.html.erb
@@ -52,6 +52,12 @@
     <%= link_to _("Edit"), :action => :edit, :id => @player %><br/>
     <%= link_to _("Delete"), { :action => :destroy, :id => @player }, :confirm => _('Are you sure?'), :method => :post %><br/>
     <br>
+    <%= form_tag({ :action => :merge, :id => @player }, :method => :post) do %>
+      <%= label_tag :source_player_id, _("Merge from player id") %><br/>
+      <%= text_field_tag :source_player_id, nil, :size => 10 %>
+      <%= submit_tag _("Merge") %>
+    <% end %>
+    <br>
   <% end %>
   <%= link_to _("Player"), :action => :show, :id => @player %><br/>
   <%= link_to _("Games"), :action => :games, :id => @player, :type => :played %><br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,7 @@ Rails.application.routes.draw do
   match 'player/games(/:id)(.:format)', to: 'player#games', via: legacy_verbs, as: nil
   match 'player/index(/:id)(.:format)', to: 'player#index', via: legacy_verbs, as: nil
   match 'player/list(/:id)(.:format)', to: 'player#list', via: legacy_verbs, as: nil
+  match 'player/merge(/:id)(.:format)', to: 'player#merge', via: legacy_verbs, as: nil
   match 'player/new(/:id)(.:format)', to: 'player#new', via: legacy_verbs, as: nil
   match 'player/show(/:id)(.:format)', to: 'player#show', via: legacy_verbs, as: nil
   match 'player/update(/:id)(.:format)', to: 'player#update', via: legacy_verbs, as: nil

--- a/test/unit/player_test.rb
+++ b/test/unit/player_test.rb
@@ -1,9 +1,40 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class PlayerTest < Test::Unit::TestCase
+  def test_merge_player_repoints_references_and_keeps_target_conflicts
+    target = Player.create!(name: 'Target', full_name: 'Ana', position: 'cm', birth: Date.new(1990, 1, 1), country: 'Brazil')
+    source = Player.create!(name: 'Source', full_name: 'Ana Maria', position: 'fw', birth: Date.new(1992, 2, 2), country: 'Argentina')
 
-  # Replace this with your real tests.
-  def test_truth
-    assert true
+    goal = Goal.create!(player_id: source.id, game_id: games(:first).id, team_id: teams(:first).id, time: 10, penalty: false, own_goal: false)
+    source_player_game = PlayerGame.create!(player_id: source.id, game_id: games(:first).id, team_id: teams(:first).id, on: 0, off: 90, yellow: false, red: false)
+    source_team_player = TeamPlayer.create!(player_id: source.id, team_id: teams(:first).id, championship_id: championships(:first).id)
+
+    target.merge_player(source)
+
+    assert_not Player.exists?(source.id)
+    assert_equal target.id, goal.reload.player_id
+    assert_equal target.id, source_player_game.reload.player_id
+    assert_equal target.id, source_team_player.reload.player_id
+
+    target.reload
+    assert_equal 'Ana Maria', target.full_name
+    assert_equal 'cm', target.position
+    assert_equal Date.new(1990, 1, 1), target.birth
+    assert_equal 'Brazil', target.country
+  end
+
+  def test_merge_player_uses_source_when_target_fields_are_blank
+    target = Player.create!(name: 'Target 2', full_name: nil, position: nil, birth: nil, country: nil)
+    source = Player.create!(name: 'Source 2', full_name: 'Long Source Name', position: 'dr', birth: Date.new(1995, 5, 5), country: 'Uruguay')
+
+    target.merge_player(source)
+
+    assert_not Player.exists?(source.id)
+
+    target.reload
+    assert_equal 'Long Source Name', target.full_name
+    assert_equal 'dr', target.position
+    assert_equal Date.new(1995, 5, 5), target.birth
+    assert_equal 'Uruguay', target.country
   end
 end

--- a/test/unit/player_test.rb
+++ b/test/unit/player_test.rb
@@ -2,8 +2,8 @@ require File.dirname(__FILE__) + '/../test_helper'
 
 class PlayerTest < Test::Unit::TestCase
   def test_merge_player_repoints_references_and_keeps_target_conflicts
-    target = Player.create!(name: 'Target', full_name: 'Ana', position: 'cm', birth: Date.new(1990, 1, 1), country: 'Brazil')
-    source = Player.create!(name: 'Source', full_name: 'Ana Maria', position: 'fw', birth: Date.new(1992, 2, 2), country: 'Argentina')
+    target = Player.create!(name: 'Target', full_name: 'Ana', position: 'cm', birth: Date.new(1990, 1, 1), country: 'Brazil', sofascore_id: 'target-sofascore')
+    source = Player.create!(name: 'Source', full_name: 'Ana Maria', position: 'fw', birth: Date.new(1992, 2, 2), country: 'Argentina', sofascore_id: 'source-sofascore')
 
     goal = Goal.create!(player_id: source.id, game_id: games(:first).id, team_id: teams(:first).id, time: 10, penalty: false, own_goal: false)
     source_player_game = PlayerGame.create!(player_id: source.id, game_id: games(:first).id, team_id: teams(:first).id, on: 0, off: 90, yellow: false, red: false)
@@ -21,11 +21,12 @@ class PlayerTest < Test::Unit::TestCase
     assert_equal 'cm', target.position
     assert_equal Date.new(1990, 1, 1), target.birth
     assert_equal 'Brazil', target.country
+    assert_equal 'target-sofascore', target.sofascore_id
   end
 
   def test_merge_player_uses_source_when_target_fields_are_blank
-    target = Player.create!(name: 'Target 2', full_name: nil, position: nil, birth: nil, country: nil)
-    source = Player.create!(name: 'Source 2', full_name: 'Long Source Name', position: 'dr', birth: Date.new(1995, 5, 5), country: 'Uruguay')
+    target = Player.create!(name: 'Target 2', full_name: nil, position: nil, birth: nil, country: nil, sofascore_id: nil)
+    source = Player.create!(name: 'Source 2', full_name: 'Long Source Name', position: 'dr', birth: Date.new(1995, 5, 5), country: 'Uruguay', sofascore_id: 'source-blank-case')
 
     target.merge_player(source)
 
@@ -36,5 +37,6 @@ class PlayerTest < Test::Unit::TestCase
     assert_equal 'dr', target.position
     assert_equal Date.new(1995, 5, 5), target.birth
     assert_equal 'Uruguay', target.country
+    assert_equal 'source-blank-case', target.sofascore_id
   end
 end


### PR DESCRIPTION
### Motivation

- Provide a way to merge duplicate players so associated records point to a single canonical player and duplicate records are removed.
- Ensure important player attributes are preserved on conflicts while filling empty fields from the source player.

### Description

- Add `Player#merge_player` which runs in a transaction, repoints `Goal`, `PlayerGame`, and `TeamPlayer` records from the source to the target, merges attribute values (keeping the longer `full_name` and filling blanks with source values), saves the target and destroys the source via `destroy!`.
- Add a controller action `PlayerController#merge` that finds the target and source players, calls `merge_player`, handles `ActiveRecord::RecordNotFound` and redirects back to the target `:show` with a flash notice.
- Add a route for `player/merge` mapped to the new `merge` action and add a simple merge form to the player `show` view to accept a `source_player_id` and submit the merge.
- Add unit tests in `test/unit/player_test.rb` covering repointing of associations, preservation of conflicting fields, and filling target blank fields from the source.

### Testing

- Added tests `test_merge_player_repoints_references_and_keeps_target_conflicts` and `test_merge_player_uses_source_when_target_fields_are_blank` in `test/unit/player_test.rb` and ran them with `rails test test/unit/player_test.rb` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae332d8f008330b307b3447f3441f6)