### PR TITLE
Move sidebar navigation links to top of entity sidebars and remove duplicates

### DIFF
--- a/app/views/championship/_nav_side.html.erb
+++ b/app/views/championship/_nav_side.html.erb
@@ -1,4 +1,12 @@
 <% @current_phase ||= @championship.phases[-1] %>
+<%= link_to _("Table"), :action => :phases, :id => @championship,
+                     :phase => @current_phase %><br/>
+<%= link_to _("Games"), :action => :games, :id => @championship,
+                     :phase => @current_phase %><br/>
+<%= link_to _("Teams"), :action => :team, :id => @championship %><br/>
+<%= link_to _("Crowd"), :action => :crowd, :id => @championship %><br/>
+<%= link_to _("Players"), :action => :player_list, :id => @championship %><br/>
+
 <% if can? :manage, @championship %>
   <% backfill_start_message = _("Starting odds history backfill...") %>
   <% backfill_error_message = _("Cant start odds history backfill") %>
@@ -41,10 +49,3 @@ function start_phase_scrape() {
 <% end %>
 <br/>
 <% end %>
-<%= link_to _("Table"), :action => :phases, :id => @championship,
-                     :phase => @current_phase %><br/>
-<%= link_to _("Games"), :action => :games, :id => @championship,
-                     :phase => @current_phase %><br/>
-<%= link_to _("Teams"), :action => :team, :id => @championship %><br/>
-<%= link_to _("Crowd"), :action => :crowd, :id => @championship %><br/>
-<%= link_to _("Players"), :action => :player_list, :id => @championship %><br/>

--- a/app/views/championship/_nav_side.html.erb
+++ b/app/views/championship/_nav_side.html.erb
@@ -8,6 +8,7 @@
 <%= link_to _("Players"), :action => :player_list, :id => @championship %><br/>
 
 <% if can? :manage, @championship %>
+  <br/>
   <% backfill_start_message = _("Starting odds history backfill...") %>
   <% backfill_error_message = _("Cant start odds history backfill") %>
 <script type="text/javascript">

--- a/app/views/player/show.html.erb
+++ b/app/views/player/show.html.erb
@@ -48,7 +48,10 @@
 <%= render :partial => "comment/comments", :locals => { :object => @player } %>
 
 <% content_for :sidebar do %>
+  <%= link_to _("Player"), :action => :show, :id => @player %><br/>
+  <%= link_to _("Games"), :action => :games, :id => @player, :type => :played %><br/>
   <% if can? :manage, @player %>
+    <br>
     <%= link_to _("Edit"), :action => :edit, :id => @player %><br/>
     <%= link_to _("Delete"), { :action => :destroy, :id => @player }, :confirm => _('Are you sure?'), :method => :post %><br/>
     <br>
@@ -57,8 +60,5 @@
       <%= text_field_tag :source_player_id, nil, :size => 10 %>
       <%= submit_tag _("Merge") %>
     <% end %>
-    <br>
   <% end %>
-  <%= link_to _("Player"), :action => :show, :id => @player %><br/>
-  <%= link_to _("Games"), :action => :games, :id => @player, :type => :played %><br/>
 <% end %>

--- a/app/views/referee/show.html.erb
+++ b/app/views/referee/show.html.erb
@@ -27,11 +27,11 @@
 <%= render :partial => "comment/comments", :locals => { :object => @referee } %>
 
 <%= content_for :sidebar do %>
-  <% if can? :manage, @referee %>
-    <%= link_to _("Edit"), :action => :edit, :id => @referee %><br/>
-    <%= link_to _("Delete"), { :action => :destroy, :id => @referee }, data: {:confirm => _('Are you sure?')}, :method => :post %><br/>
-    <br/>
-  <% end %>
   <%= link_to _("Referee"), action: :show, id: @referee %><br>
   <%= link_to _("Games"), action: :games, id: @referee %><br>
+  <% if can? :manage, @referee %>
+    <br/>
+    <%= link_to _("Edit"), :action => :edit, :id => @referee %><br/>
+    <%= link_to _("Delete"), { :action => :destroy, :id => @referee }, data: {:confirm => _('Are you sure?')}, :method => :post %><br/>
+  <% end %>
 <% end %>

--- a/app/views/stadium/show.html.erb
+++ b/app/views/stadium/show.html.erb
@@ -25,11 +25,11 @@
 <%= render :partial => "comment/comments", :locals => { :object => @stadium } %>
 
 <% content_for :sidebar do %>
-  <% if can? :manage, @stadium %>
-    <%= link_to _("Edit"), :action => :edit, :id => @stadium %><br>
-    <%= link_to _("Delete"), { :action => :destroy, :id => @stadium }, data: {:confirm => _('Are you sure?')}, :method => :post %><br/>
-    <br>
-  <% end %>
   <%= link_to _("Stadium"), action: :show, id: @stadium %><br>
   <%= link_to _("Games"), action: :games, id: @stadium %><br>
+  <% if can? :manage, @stadium %>
+    <br>
+    <%= link_to _("Edit"), :action => :edit, :id => @stadium %><br>
+    <%= link_to _("Delete"), { :action => :destroy, :id => @stadium }, data: {:confirm => _('Are you sure?')}, :method => :post %><br/>
+  <% end %>
 <% end %>

--- a/app/views/team/show.html.erb
+++ b/app/views/team/show.html.erb
@@ -64,11 +64,11 @@
 <%= render :partial => "comment/comments", :locals => { :object => @team } %>
 
 <% content_for :sidebar do %>
-  <% if can? :manage, @team %>
-    <%= link_to _("Edit team"), :action => :edit, :id => @team %><br/>
-    <%= link_to _("Delete team"), { :action => :destroy, :id => @team }, data: { confirm: _('Are you sure?') }, :method => :post %><br/>
-    <br/>
-  <% end %>
   <%= link_to _("Team"), :action => :show, :id => @team %><br/>
   <%= link_to _("Games"), :action => :games, :id => @team, :type => :played %><br/>
+  <% if can? :manage, @team %>
+    <br/>
+    <%= link_to _("Edit team"), :action => :edit, :id => @team %><br/>
+    <%= link_to _("Delete team"), { :action => :destroy, :id => @team }, data: { confirm: _('Are you sure?') }, :method => :post %><br/>
+  <% end %>
 <% end %>


### PR DESCRIPTION
### Motivation
- Make the sidebar navigation links consistently visible and avoid duplicated link blocks in several entity show views.
- Ensure admin controls remain grouped separately from the main navigation links for clarity.

### Description
- Moved the primary navigation links to the top of `content_for :sidebar` in `player/show`, `referee/show`, `stadium/show`, and `team/show` so they appear before admin controls and removed the duplicated links at the bottom. 
- Moved the championship navigation links in `app/views/championship/_nav_side.html.erb` to the top of the partial and removed the duplicate block that appeared after admin-only controls. 
- Minor formatting adjustments to line breaks (`<br/>` / `<br>`) and whitespace in the updated view files.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af306420688330a1190e7c3741ca9f)