### PR TITLE
Default S3 bucket to golaberto_development when unset

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,8 +59,12 @@ module Golaberto
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
+    default_s3_bucket = 'golaberto_development'
     raw_s3_credentials = Rails.application.credentials.s3
     s3_credentials = raw_s3_credentials.respond_to?(:to_h) ? raw_s3_credentials.to_h : {}
+    bucket = s3_credentials[:bucket] || s3_credentials['bucket'] || default_s3_bucket
+    s3_credentials[:bucket] ||= bucket
+    s3_credentials['bucket'] ||= bucket
 
     config.paperclip_defaults = {
       storage: :s3,
@@ -69,7 +73,6 @@ module Golaberto
       s3_headers: { 'Cache-Control' => 'max-age=315576000', 'Expires' => 10.years.from_now.httpdate },
     }
 
-    bucket = s3_credentials[:bucket] || s3_credentials['bucket']
-    config.golaberto_image_url_prefix = bucket ? "https://s3.amazonaws.com/#{bucket}" : ''
+    config.golaberto_image_url_prefix = "https://s3.amazonaws.com/#{bucket}"
   end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,4 +1,6 @@
-Paperclip.interpolates :bucket  do |attachment, style|
-  Rails.application.credentials.s3[:bucket]
+Paperclip.interpolates :bucket do |_attachment, _style|
+  configured_bucket = Rails.application.config.paperclip_defaults.dig(:s3_credentials, :bucket) ||
+                      Rails.application.config.paperclip_defaults.dig(:s3_credentials, 'bucket')
+  configured_bucket.presence || 'golaberto_development'
 end
 


### PR DESCRIPTION
### Motivation
- Ensure the application has a usable S3 bucket when credentials do not provide one so image URLs and Paperclip behave consistently.
- Prevent nil/empty bucket lookups in code that builds S3 URLs or uses Paperclip interpolations.

### Description
- Added a `default_s3_bucket = 'golaberto_development'` and ensure `:bucket` and `'bucket'` keys are populated in `config.paperclip_defaults[:s3_credentials]` when missing in `config/application.rb`.
- Always set `config.golaberto_image_url_prefix` to the resolved S3 bucket URL so helpers/models can rely on it.
- Updated `Paperclip.interpolates :bucket` in `config/initializers/paperclip.rb` to read the configured Paperclip credentials first and fall back to `'golaberto_development'` if none is present.
- Files changed: `config/application.rb` and `config/initializers/paperclip.rb`.

### Testing
- Ran `bundle exec ruby -c config/application.rb` and `bundle exec ruby -c config/initializers/paperclip.rb` and both returned `Syntax OK` (succeeded).
- Ran `bin/rails runner "puts Rails.application.config.paperclip_defaults[:s3_credentials][:bucket]; puts Rails.configuration.golaberto_image_url_prefix"` which printed the resolved bucket and URL (succeeded and showed `golaberto_development` and the corresponding S3 URL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af99513b7c83309e06da3e9e94ea0d)