### PR TITLE
Add feature to clone a phase into a new championship

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -447,6 +447,13 @@ class ChampionshipController < ApplicationController
     @pagy, @games = pagy(@championship.games.reorder("attendance DESC"), items: 10)
   end
 
+  def clone_phase
+    @championship = Championship.find(params["id"])
+    phase = @championship.phases.find(params["phase"])
+    cloned_championship = @championship.clone_phase_to_new_championship!(phase)
+    redirect_to :action => :phases, :id => cloned_championship, :phase => cloned_championship.phases.first
+  end
+
   def destroy
     Championship.find(params["id"]).destroy
     redirect_to action: :list

--- a/app/models/championship.rb
+++ b/app/models/championship.rb
@@ -63,4 +63,50 @@ class Championship < ApplicationRecord
   def avg_team_rating
     @avg_team_rating ||= begin teams.sort_by{|t|-t.rating.to_f}.each_with_index.map{|t,i|t.rating.to_f * (0.7)**i}.sum / teams.each_with_index.map{|t,i| 0.7**i}.sum rescue 0 end
   end
+
+  def clone_phase_to_new_championship!(phase)
+    raise ActiveRecord::RecordNotFound if phase.championship_id != id
+
+    ActiveRecord::Base.transaction do
+      cloned_championship = Championship.create!(
+        name: "#{name} - #{phase.name}",
+        begin: self.begin,
+        end: self.end,
+        point_win: point_win,
+        point_draw: point_draw,
+        point_loss: point_loss,
+        category_id: category_id,
+        show_country: show_country,
+        region: region,
+        region_name: region_name
+      )
+
+      cloned_phase = cloned_championship.phases.create!(
+        name: phase.name,
+        order_by: 1,
+        sort: phase.sort,
+        bonus_points: phase.bonus_points,
+        bonus_points_threshold: phase.bonus_points_threshold,
+        scrape_url: phase.scrape_url
+      )
+
+      phase.groups.includes(:team_groups).order(:id).each do |group|
+        cloned_group = cloned_phase.groups.create!(
+          name: group.name,
+          zones: group.zones
+        )
+
+        group.team_groups.each do |team_group|
+          cloned_group.team_groups.create!(
+            team_id: team_group.team_id,
+            add_sub: team_group.add_sub,
+            bias: team_group.bias,
+            comment: team_group.comment
+          )
+        end
+      end
+
+      cloned_championship
+    end
+  end
 end

--- a/app/views/championship/_nav_side.html.erb
+++ b/app/views/championship/_nav_side.html.erb
@@ -53,5 +53,9 @@ function start_phase_scrape() {
   <button type="button" onclick="start_phase_scrape()"><%= _("Scrape") %></button>
   <div id="scrape_status"></div>
 <% end %>
+<%= link_to _("Clone phase to new championship"),
+            { :action => :clone_phase, :id => @championship, :phase => @current_phase },
+            :method => :post,
+            :data => { :confirm => _("Create a new championship with only a copy of this phase?") } %><br/>
 <br/>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
   match 'championship/list(/:id)(.:format)', to: 'championship#list', via: legacy_verbs, as: nil
   match 'championship/new(/:id)(.:format)', to: 'championship#new', via: legacy_verbs, as: nil
   match 'championship/new_game(/:id)(.:format)', to: 'championship#new_game', via: legacy_verbs, as: nil
+  match 'championship/clone_phase(/:id)(.:format)', to: 'championship#clone_phase', via: legacy_verbs, as: nil
   match 'championship/phases(/:id)(.:format)', to: 'championship#phases', via: legacy_verbs, as: nil
   match 'championship/player_list(/:id)(.:format)', to: 'championship#player_list', via: legacy_verbs, as: nil
   match 'championship/player_show(/:id)(.:format)', to: 'championship#player_show', via: legacy_verbs, as: nil

--- a/test/unit/championship_test.rb
+++ b/test/unit/championship_test.rb
@@ -1,9 +1,58 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class ChampionshipTest < Test::Unit::TestCase
+  def test_clone_phase_to_new_championship_copies_phase_groups_and_teams_without_games_or_players
+    category = Category.find(1)
+    source_championship = Championship.create!(
+      name: "Source Championship",
+      begin: Date.new(2025, 1, 1),
+      end: Date.new(2025, 12, 31),
+      point_win: 3,
+      point_draw: 1,
+      point_loss: 0,
+      category: category,
+      region: :national,
+      region_name: "Brazil"
+    )
 
-  # Replace this with your real tests.
-  def test_truth
-    assert true
+    phase = source_championship.phases.create!(
+      name: "Phase A",
+      order_by: 1,
+      sort: "pt,gd",
+      bonus_points: 2,
+      bonus_points_threshold: 5
+    )
+
+    group = phase.groups.create!(
+      name: "Group A",
+      zones: [{ "name" => "Promotion", "color" => "#00ff00", "position" => [1] }]
+    )
+
+    team_one = Team.find(1)
+    team_two = Team.find(2)
+    group.team_groups.create!(team: team_one, add_sub: 1, bias: 2, comment: "favored")
+    group.team_groups.create!(team: team_two, add_sub: -1, bias: -2, comment: "underdog")
+
+    phase.games.create!(home: team_one, away: team_two, played: true, date: Time.zone.now, home_score: 1, away_score: 0)
+    TeamPlayer.create!(championship: source_championship, team: team_one, player: Player.create!(name: "Player One", country: "Brazil"))
+
+    cloned_championship = source_championship.clone_phase_to_new_championship!(phase)
+    cloned_phase = cloned_championship.phases.first
+    cloned_group = cloned_phase.groups.first
+
+    assert_equal "Source Championship - Phase A", cloned_championship.name
+    assert_equal source_championship.begin, cloned_championship.begin
+    assert_equal source_championship.end, cloned_championship.end
+    assert_equal 1, cloned_championship.phases.count
+    assert_equal "Phase A", cloned_phase.name
+    assert_equal "pt,gd", cloned_phase.sort
+    assert_equal 2, cloned_phase.bonus_points
+    assert_equal 5, cloned_phase.bonus_points_threshold
+    assert_equal 1, cloned_phase.groups.count
+    assert_equal "Group A", cloned_group.name
+    assert_equal group.zones, cloned_group.zones
+    assert_equal [team_one.id, team_two.id].sort, cloned_group.team_groups.pluck(:team_id).sort
+    assert_equal 0, cloned_phase.games.count
+    assert_equal 0, TeamPlayer.where(championship_id: cloned_championship.id).count
   end
 end


### PR DESCRIPTION
### Motivation
- Provide a UI action to duplicate a single phase (with its groups and team assignments) into a new standalone championship to simplify reuse of phase configurations.
- Ensure the clone operation creates a new championship and phase atomically and does not copy games or player assignments.

### Description
- Added `clone_phase` action to `ChampionshipController` which finds the source phase and redirects to the newly created championship phase after cloning. 
- Implemented `Championship#clone_phase_to_new_championship!` which performs an atomic transaction to create a new `Championship`, duplicate the selected `Phase`, its `Groups`, and each group's `TeamGroup` rows, and raises if the phase does not belong to the source championship. 
- Added a link in the championship side navigation (`_nav_side.html.erb`) to trigger the clone action with confirmation, and registered the legacy route `championship/clone_phase` in `config/routes.rb`.
- Added a unit test `test_clone_phase_to_new_championship_copies_phase_groups_and_teams_without_games_or_players` in `test/unit/championship_test.rb` that verifies the new championship/phase are created, copies groups and team assignments, and ensures games and team_players are not copied.

### Testing
- Added unit test `ChampionshipTest#test_clone_phase_to_new_championship_copies_phase_groups_and_teams_without_games_or_players` and executed the test suite with `rake test`, which passed for the modified tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c168a72d50833083d960dae34ce4a3)