### PR TITLE
Batch load next games for championship table in a single query

### DIFF
--- a/app/helpers/championship_helper.rb
+++ b/app/helpers/championship_helper.rb
@@ -37,6 +37,21 @@ module ChampionshipHelper
     end
   end
 
+  def next_games_by_team(phase, team_ids, start_date = Date.today)
+    return {} if phase.nil? || team_ids.blank?
+
+    team_ids = team_ids.uniq
+    games = Game.where("phase_id = ? AND played = ? AND date >= ? AND (home_id IN (?) OR away_id IN (?))",
+                       phase.id, false, start_date, team_ids, team_ids)
+                .includes(:home, :away)
+                .order(:date, :id)
+
+    games.each_with_object({}) do |game, hash|
+      hash[game.home_id] ||= game
+      hash[game.away_id] ||= game
+    end
+  end
+
   class TeamCampaign
     attr_reader :points, :games, :wins, :draws, :losses,
                 :goals_for, :goals_against, :goals_aet, :goals_pen,
@@ -192,9 +207,5 @@ module ChampionshipHelper
       @goals_for / (@goals_against + 0.0000001)
     end
 
-    def next_game
-      Game.where("(home_id = ? OR away_id = ?) AND phase_id = ? AND played = ? AND date >= ?", @team_id, @team_id, @team_group.group.phase, false, Date.today)
-          .includes(:home, :away).order(:date).first
-    end
   end
 end

--- a/app/views/championship/_table.html.erb
+++ b/app/views/championship/_table.html.erb
@@ -140,11 +140,14 @@
   <% pos = 0 %>
   <% notes = Array.new %>
   <% max_form = 0 %>
-  <% group.team_table.each do |t|
+  <% team_table = group.team_table %>
+  <% team_ids = team_table.map { |t| t[0].team_id } %>
+  <% next_games = next_games_by_team(group.phase, team_ids) %>
+  <% team_table.each do |t|
     stats = t[1]
     max_form = [stats.form.last(5).size, max_form].max
   end %>
-  <% group.team_table.each do |t|
+  <% team_table.each do |t|
     team = t[0].team
     stats = t[1]
     note_number = ""
@@ -206,7 +209,7 @@
     title_popup = ""
     unless omit_popup
       last_game = stats.last_game
-      next_game = stats.next_game
+      next_game = next_games[team.id]
       header_body = ""
       unless last_game.nil?
         header_body << sprintf("%02d", game_date(last_game).day) << "/"


### PR DESCRIPTION
### Motivation
- Rendering the championship table executed a `next_game` lookup per team which caused an N+1 query pattern and extra DB round-trips while building the popup header. 
- The change aims to fetch all upcoming games for the phase/team set in one query and map each team to its nearest upcoming match to reduce DB queries and improve rendering performance.

### Description
- Added helper `next_games_by_team(phase, team_ids, start_date = Date.today)` in `app/helpers/championship_helper.rb` which performs a single SQL query, eager-loads `:home` and `:away`, orders by `date, id`, and returns a hash mapping team id to its next `Game`.
- Removed the per-team method `TeamCampaign#next_game` to avoid per-row queries (previously in `app/helpers/championship_helper.rb`).
- Updated `app/views/championship/_table.html.erb` to compute `team_table` once, collect `team_ids`, call `next_games_by_team` once, and use `next_games[team.id]` inside the row loop instead of calling `stats.next_game` for each team.
- The new query uses `phase.id`, `played = false`, and `date >= start_date` to find upcoming games and returns the earliest match per team.

### Testing
- Ran the functional championship tests with `bin/rails test test/functional/championship_controller_test.rb`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17c76e0088330b3013688a8077961)