### PR TITLE
Speed up championship phases page rendering

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -100,10 +100,10 @@ class ChampionshipController < ApplicationController
   end
 
   def phases
-    @championship = Championship.includes(:phases).find(params[:id])
+    @championship = Championship.includes(phases: { teams: :team_geocode }).find(params[:id])
     # Use an empty phase instead of nil if none is passed.
     @current_phase = Phase.new
-    @current_phase = @championship.phases.includes(:teams).find(params[:phase]) if params[:phase]
+    @current_phase = @championship.phases.find(params[:phase]) if params[:phase]
     if @current_phase
       @hide_odds = @current_phase.games.find_by_played(false) == nil
     end

--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -103,7 +103,7 @@ class ChampionshipController < ApplicationController
     @championship = Championship.includes(phases: { teams: :team_geocode }).find(params[:id])
     # Use an empty phase instead of nil if none is passed.
     @current_phase = Phase.new
-    @current_phase = @championship.phases.find(params[:phase]) if params[:phase]
+    @current_phase = @championship.phases.includes(teams: :team_geocode).find(params[:phase]) if params[:phase]
     if @current_phase
       @hide_odds = @current_phase.games.find_by_played(false) == nil
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -99,7 +99,7 @@ class Group < ApplicationRecord
   def team_table
     @team_table ||= begin
       played_games = games.where(played: true).
-          includes(:phase, [:phase => :championship ]).
+          includes(:home, :away, :phase, [:phase => :championship ]).
           order(:date)
       stats = Hash.new
       team_groups.each do |team_group|

--- a/app/views/championship/_table.html.erb
+++ b/app/views/championship/_table.html.erb
@@ -91,6 +91,11 @@
         }
         </style>
         <script type="text/javascript">
+          var oddsNumberFormatter_<%= group.id %> = new Intl.NumberFormat("<%= I18n.locale %>", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+          });
+
           $.widget("custom.iconselectmenu", $.ui.selectmenu, {
 						_create: function() {
 							this._super();
@@ -163,7 +168,7 @@
                 if (value == null) {
                   cell.text("");
                 } else {
-                  cell.text(Number(value).toFixed(2));
+                  cell.text(oddsNumberFormatter_<%= group.id %>.format(Number(value)));
                 }
                 cell.css("background-color", ui.item.element.attr("data-color") || "lightgray");
               });
@@ -286,10 +291,14 @@
          <% if not omit_columns[:odds] then %>
            <%= content_tag :td, "", class: "odds_spacing" %>
            <% first_zone = group.zones.first %>
-           <% first_zone_odds = first_zone ? t[0].calculate_odds(first_zone["position"]) : nil %>
+           <% first_odds = if first_zone
+                            t[0].calculate_odds(first_zone["position"])
+                          elsif t[0].odds
+                            t[0].odds[0]
+                          end %>
            <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "lightgray" %>
            <%= content_tag :td,
-                           first_zone_odds ? number_to_rounded(first_zone_odds, precision: 2) : "",
+                           first_odds.nil? ? "" : number_to_rounded(first_odds, precision: 2),
                            "data-group-id": group.id,
                            "data-odds-array": (t[0].odds || []).to_json,
                            class: "odds odds-value",

--- a/app/views/championship/_table.html.erb
+++ b/app/views/championship/_table.html.erb
@@ -65,7 +65,8 @@
           <option value="<%= i %>"
                   title="<%= sprintf(_("odds of %s"), i)%>"
                   data-rank="<%= i %>"
-                  data-color="black"><%=i%></option>
+                  data-color="black"
+                  data-cell-color="lightgray"><%=i%></option>
         <% end %>
         </select>
         <style>
@@ -170,7 +171,7 @@
                 } else {
                   cell.text(oddsNumberFormatter_<%= group.id %>.format(Number(value)));
                 }
-                var bgColor = ui.item.element.attr("data-color") || "black";
+                var bgColor = ui.item.element.attr("data-cell-color") || ui.item.element.attr("data-color") || "lightgray";
                 cell.css("background-color", bgColor);
                 cell.css("color", bgColor === "black" ? "white" : "");
               });
@@ -298,7 +299,7 @@
                           elsif t[0].odds
                             t[0].odds[0]
                           end %>
-           <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "black" %>
+           <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "lightgray" %>
            <%= content_tag :td,
                            first_odds.nil? ? "" : number_to_rounded(first_odds, precision: 2),
                            "data-group-id": group.id,

--- a/app/views/championship/_table.html.erb
+++ b/app/views/championship/_table.html.erb
@@ -56,10 +56,16 @@
       <%= content_tag :th, class: "odds", style: "text-align: center" do -%>
         <select id="oddsSelect_<%= group.id %>" tabindex=1>
         <% group.zones.each do |zone| %>
-          <option value="<%= zone["name"] %>" data-title="<%= sprintf(_("odds of %s"), zone["name"])%>" data-color="<%= zone["color"]%>">▣</option>
+          <option value="<%= zone["name"] %>"
+                  data-title="<%= sprintf(_("odds of %s"), zone["name"])%>"
+                  data-color="<%= zone["color"]%>"
+                  data-positions="<%= zone["position"].to_json %>">▣</option>
         <% end %>
         <% (1..group.teams.size).each do |i| %>
-          <option value="<%= i %>" title="<%= sprintf(_("odds of %s"), i)%>"><%=i%></option>
+          <option value="<%= i %>"
+                  title="<%= sprintf(_("odds of %s"), i)%>"
+                  data-rank="<%= i %>"
+                  data-color="lightgray"><%=i%></option>
         <% end %>
         </select>
         <style>
@@ -125,11 +131,41 @@
           $("#oddsSelect_<%=group.id%>").iconselectmenu({
             width: false,
             change: function(event, ui) {
-              $("td[data-group-id=<%=group.id%>][data-zone-name]").each(function(index) {
-                $(this).hide();
-              });
-              $("td[data-group-id=<%=group.id%>][data-zone-name='" + ui.item.value + "']").each(function(index) {
-                $(this).show();
+              $("td.odds-value[data-group-id=<%=group.id%>]").each(function(index) {
+                var cell = $(this);
+                var oddsArray = cell.data("oddsArray");
+                if (!oddsArray) {
+                  try {
+                    oddsArray = JSON.parse(cell.attr("data-odds-array") || "[]");
+                  } catch (e) {
+                    oddsArray = [];
+                  }
+                  cell.data("oddsArray", oddsArray);
+                }
+
+                var value = null;
+                var rank = ui.item.element.attr("data-rank");
+                var zonePositions = ui.item.element.attr("data-positions");
+                if (rank) {
+                  value = oddsArray[Number(rank) - 1];
+                } else if (zonePositions) {
+                  try {
+                    var positions = JSON.parse(zonePositions);
+                    value = positions.reduce(function(sum, pos) {
+                      var v = oddsArray[Number(pos) - 1];
+                      return sum + (v == null ? 0 : Number(v));
+                    }, 0);
+                  } catch (e) {
+                    value = null;
+                  }
+                }
+
+                if (value == null) {
+                  cell.text("");
+                } else {
+                  cell.text(Number(value).toFixed(2));
+                }
+                cell.css("background-color", ui.item.element.attr("data-color") || "lightgray");
               });
             }
           });
@@ -249,17 +285,15 @@
          <%= content_tag :td, stats.goals_diff unless omit_columns[:GD] %>
          <% if not omit_columns[:odds] then %>
            <%= content_tag :td, "", class: "odds_spacing" %>
-           <% first = true %>
-           <% group.zones.each do |zone| %>
-             <% odds = t[0].calculate_odds(zone["position"]) %>
-             <%= content_tag :td, odds ? number_to_rounded(odds, precision: 2) : "", "data-group-id": group.id, "data-zone-name": zone["name"], class: "odds", style: "background-color: #{zone["color"]}; display: #{first ? "table-cell" : "none"}" %>
-             <% first = false %>
-           <% end %>
-           <% (1..group.teams.size).each do |i| %>
-             <% odds = if t[0].odds then t[0].odds[i-1] end %>
-             <%= content_tag :td, odds ? number_to_rounded(odds, precision: 2) : "", "data-group-id": group.id, "data-zone-name": i, class: "odds", style: "background-color: lightgray; display: #{first ? "table-cell" : "none"}" %>
-             <% first = false %>
-           <% end %>
+           <% first_zone = group.zones.first %>
+           <% first_zone_odds = first_zone ? t[0].calculate_odds(first_zone["position"]) : nil %>
+           <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "lightgray" %>
+           <%= content_tag :td,
+                           first_zone_odds ? number_to_rounded(first_zone_odds, precision: 2) : "",
+                           "data-group-id": group.id,
+                           "data-odds-array": (t[0].odds || []).to_json,
+                           class: "odds odds-value",
+                           style: "background-color: #{first_color}" %>
          <% end %>
        </tr>
      <% end %>

--- a/app/views/championship/_table.html.erb
+++ b/app/views/championship/_table.html.erb
@@ -65,7 +65,7 @@
           <option value="<%= i %>"
                   title="<%= sprintf(_("odds of %s"), i)%>"
                   data-rank="<%= i %>"
-                  data-color="lightgray"><%=i%></option>
+                  data-color="black"><%=i%></option>
         <% end %>
         </select>
         <style>
@@ -170,7 +170,9 @@
                 } else {
                   cell.text(oddsNumberFormatter_<%= group.id %>.format(Number(value)));
                 }
-                cell.css("background-color", ui.item.element.attr("data-color") || "lightgray");
+                var bgColor = ui.item.element.attr("data-color") || "black";
+                cell.css("background-color", bgColor);
+                cell.css("color", bgColor === "black" ? "white" : "");
               });
             }
           });
@@ -296,13 +298,13 @@
                           elsif t[0].odds
                             t[0].odds[0]
                           end %>
-           <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "lightgray" %>
+           <% first_color = first_zone.is_a?(Hash) ? first_zone["color"] : "black" %>
            <%= content_tag :td,
                            first_odds.nil? ? "" : number_to_rounded(first_odds, precision: 2),
                            "data-group-id": group.id,
                            "data-odds-array": (t[0].odds || []).to_json,
                            class: "odds odds-value",
-                           style: "background-color: #{first_color}" %>
+                           style: "background-color: #{first_color}; color: #{first_color == "black" ? "white" : "inherit"}" %>
          <% end %>
        </tr>
      <% end %>

--- a/app/views/team/_geolocation.html.erb
+++ b/app/views/team/_geolocation.html.erb
@@ -70,6 +70,30 @@ if I18n.locale == :"pt-BR"
 end
 
 static_map_url = map_static_path(static_map_params)
+
+cities_data = teams.map do |team|
+  geocode = team.team_geocode.try(:data).try(:at, 0)
+  localized_place =
+    if geocode
+      localized_name = if I18n.locale == :"pt-BR"
+                         geocode.try(:dig, "namedetails", "name:pt") || geocode.try(:dig, "namedetails", "name:en") || geocode["name"]
+                       else
+                         geocode.try(:dig, "namedetails", "name:en") || geocode["name"]
+                       end
+      "#{localized_name}, #{_(team.country)}"
+    else
+      _(team.country)
+    end
+
+  [
+    "#{team.city}, #{team.country}",
+    team.name,
+    team.logo.url(:thumb),
+    geocode.try(:[], "lat").to_f,
+    geocode.try(:[], "lon").to_f,
+    localized_place
+  ]
+end
 %>
 <script src="https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js"></script>
 <style>
@@ -80,11 +104,7 @@ button.gm-ui-hover-effect {
 
 <script>
 // List of city names
-const cities = [
-<% teams.each do |team| %>
-  [ '<%= team.city %>, <%= team.country %>', '<%= team.name %>', '<%= team.logo.url(:thumb) %>', <%= team.team_geocode.try(:data).try(:at, 0).try(:to_json).try(:html_safe) %>, '<%= _(team.country) %>' ],
-<% end %>
-];
+const cities = <%= raw cities_data.to_json %>;
 
 function initMap() {
     const map = new google.maps.Map(document.getElementById('map'), {
@@ -104,15 +124,8 @@ function initMap() {
     const markers = [];
 
     cities.forEach(cityName => {
-      var location = {lat: 0.0, lng: 0.0 };
-      if (cityName[3] != null) location = {lat: Number(cityName[3].lat), lng: Number(cityName[3].lon)};
-
-      var name = cityName[4];
-      <% case I18n.locale when :"pt-BR" then %>
-      if (cityName[3] != null) name = (cityName[3]['namedetails']['name:pt'] || cityName[3]['namedetails']['name:en'] || cityName[3]['name']) + ", " + name;;
-      <% else %>
-      if (cityName[3] != null) name = (cityName[3]['namedetails']['name:en'] || cityName[3]['name']) + ", " + name;;
-      <% end %>
+      var location = {lat: Number(cityName[3]), lng: Number(cityName[4])};
+      var name = cityName[5];
 
       for (i=0; i < markers.length; i++) {
               var existingMarker = markers[i];


### PR DESCRIPTION
### Motivation
- The championship phases page was very slow to render due to many N+1 database lookups and a very large view payload (many hidden `<td>` cells per team/zone and full geocode blobs embedded in JS). 
- The goal was to cut page load time by at least 50% by reducing SQL churn and view rendering work.

### Description
- Preload team geocodes when loading a championship in `ChampionshipController#phases` by using `includes(phases: { teams: :team_geocode })` to avoid per-team geocode queries during rendering (changed `app/controllers/championship_controller.rb`).
- Preload `home` and `away` associations for games consumed by `Group#team_table` to avoid repeated team lookups when building last/next-game tooltips (changed `app/models/group.rb` to `includes(:home, :away, :phase, [:phase => :championship ])`).
- Reworked odds rendering to emit a single odds `<td>` per team row and switch displayed values client-side using per-row odds arrays and select metadata, eliminating thousands of hidden cells and reducing view CPU and HTML size (changes in `app/views/championship/_table.html.erb`).
- Slimmed down map payload by serializing only the fields used by the client (lat/lon, localized place label, thumb URL) instead of embedding full geocode JSON objects, reducing JS payload size and parsing time (changes in `app/views/team/_geolocation.html.erb`).

### Testing
- Ran `bin/rails test test/functional/championship_controller_test.rb` and it passed (`1 runs, 1 assertions, 0 failures`).
- Measured the instrumented page request with `bin/rails runner` before/after to capture total/view/db times, SQL counts and response size; results show a large improvement: before `total_ms=12889.7 view_ms=12172.4 db_ms=190.8 body_bytes=5599098 queries=395`; after `total_ms=1919.7 view_ms=1432.6 db_ms=129.1 body_bytes=480541 queries=217`.
- No automated UI screenshots were produced in this environment; backend and view instrumentation and the functional test were used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c183764338833086e4c2237a3daf53)