### PR TITLE
Optimize championship player list row loading

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -383,7 +383,7 @@ class ChampionshipController < ApplicationController
     base = TeamPlayer.stats("games.phase_id": phase_ids)
       .joins("INNER JOIN players ON players.id = player_games.player_id")
       .joins("INNER JOIN teams ON teams.id = player_games.team_id")
-      .includes(:player, :team, game: { phase: :championship })
+      .includes(:player, :team)
 
     total_count = relation_count(base)
 
@@ -405,7 +405,7 @@ class ChampionshipController < ApplicationController
     order_dir = params.dig(:order, "0", :dir) == "asc" ? "ASC" : "DESC"
     filtered = filtered.reorder(Arel.sql("#{player_list_order_sql(order_column)} #{order_dir}"))
 
-    rows = filtered.offset(page_start).limit(page_length).to_a.map { |p| player_list_row(p) }
+    rows = filtered.offset(page_start).limit(page_length).to_a.map { |p| player_list_row(p, @championship) }
 
     {
       draw: params[:draw].to_i,
@@ -444,8 +444,7 @@ class ChampionshipController < ApplicationController
     end
   end
 
-  def player_list_row(p)
-    champ = p.game.phase.championship
+  def player_list_row(p, champ)
     team = p.team
     player = p.player
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary association traversal when rendering the championship player list JSON to improve performance for paginated results.
- Avoid resolving `game -> phase -> championship` on every row when the controller already has the championship loaded.

### Description
- Stop eager-loading `game: { phase: :championship }` in `ChampionshipController#player_list_datatable_json` and keep only `:player` and `:team` in the `includes` call.
- Pass the already-loaded `@championship` into `player_list_row` instead of deriving it from `p.game.phase.championship` for every row by changing the call site to `player_list_row(p, @championship)` and the method signature to `def player_list_row(p, champ)`.
- Keep the rendered payload and URLs unchanged while reducing association work per row in the JSON endpoint.

### Testing
- Ran the targeted functional test with `bin/rails test test/functional/championship_controller_test.rb`, which completed successfully (1 run, 1 assertion, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1fa3ded448330a5842e5847712985)