### PR TITLE
Stabilize championship player list ordering

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -403,7 +403,7 @@ class ChampionshipController < ApplicationController
 
     order_column = params.dig(:order, "0", :column).to_i
     order_dir = params.dig(:order, "0", :dir) == "asc" ? "ASC" : "DESC"
-    filtered = filtered.reorder(Arel.sql("#{player_list_order_sql(order_column)} #{order_dir}"))
+    filtered = filtered.reorder(Arel.sql(player_list_order_clause(order_column, order_dir)))
 
     rows = filtered.offset(page_start).limit(page_length).to_a.map { |p| player_list_row(p, @championship) }
 
@@ -442,6 +442,10 @@ class ChampionshipController < ApplicationController
     when 17 then "reds"
     else "goals"
     end
+  end
+
+  def player_list_order_clause(index, direction)
+    "#{player_list_order_sql(index)} #{direction}, players.name ASC, players.id ASC"
   end
 
   def player_list_row(p, champ)

--- a/test/functional/championship_controller_test.rb
+++ b/test/functional/championship_controller_test.rb
@@ -11,8 +11,17 @@ class ChampionshipControllerTest < Test::Unit::TestCase
     @response   = ActionController::TestResponse.new
   end
 
-  # Replace this with your real tests.
-  def test_truth
-    assert true
+  def test_player_list_order_clause_adds_stable_tie_breakers_for_desc
+    assert_equal(
+      "goals DESC, players.name ASC, players.id ASC",
+      @controller.send(:player_list_order_clause, 4, "DESC")
+    )
+  end
+
+  def test_player_list_order_clause_adds_stable_tie_breakers_for_asc
+    assert_equal(
+      "players.name ASC, players.name ASC, players.id ASC",
+      @controller.send(:player_list_order_clause, 0, "ASC")
+    )
   end
 end


### PR DESCRIPTION
### Motivation
- The championship players list must have a stable ordering to avoid nondeterministic row order and pagination instability when multiple rows tie on the primary sort column. 
- Enforce a consistent secondary and tertiary tie-breaker so UI and API consumers see predictable results.

### Description
- Added a helper `player_list_order_clause(index, direction)` that builds the SQL `ORDER BY` clause by combining the requested column and direction followed by `players.name ASC` and `players.id ASC` as stable tie-breakers. 
- Updated the datatable ordering path in `player_list_datatable_json` to use `player_list_order_clause` when applying `reorder`. 
- Added functional tests in `test/functional/championship_controller_test.rb` to assert the generated order clause for both descending and ascending primary sorts. 
- Modified files: `app/controllers/championship_controller.rb` and `test/functional/championship_controller_test.rb`.

### Testing
- Ran `bin/rails test test/functional/championship_controller_test.rb`, which passed (2 runs, 2 assertions, 0 failures). 
- No other automated test changes were required for this focused change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c200ad87288330adf18e84534f3a55)