### PR TITLE
Downsample team rating graph after period filtering

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -77,8 +77,10 @@ class Team < ApplicationRecord
     games.joins(phase: :championship).where(championships: { category_id: Category::DEFAULT_CATEGORY }).where("date < ?", date).order(date: :desc).limit(n)
   end
 
-  def self.get_historical_ratings(team_id, threshold = 300)
+  def self.get_historical_ratings(team_id, threshold = nil)
     data = HistoricalRating.where(team_id: team_id).order(:measure_date).pluck(:measure_date, :rating).map { |d, r| [d.to_time.to_i, r.to_f] }
+    return data if threshold.nil?
+
     LTTB.downsample(data, threshold)
   end
 

--- a/app/views/team/_team_rating_graph.html.erb
+++ b/app/views/team/_team_rating_graph.html.erb
@@ -21,6 +21,7 @@ data = teams[0,3].map{|t| Team.get_historical_ratings(t.id)  }
 <script type="text/javascript">
   $(function() {
     var SECONDS_PER_DAY = 24 * 3600;
+    var DOWNSAMPLE_THRESHOLD = 300;
     var currentRange = {from: undefined, to: undefined};
 
     var getColor = function(index) {
@@ -57,6 +58,71 @@ data = teams[0,3].map{|t| Team.get_historical_ratings(t.id)  }
         }, "") +
         "<tr><td colspan=3 style='text-align: center'>" + new Date(points[0].point[0]*1000).toISOString().slice(0, 10) + "</tr>"
       ).css({top: pos.pageY + 10, left: pos.pageX + 10}).fadeIn(200);
+    };
+
+    var downsample = function(data, threshold) {
+      if (!threshold || threshold <= 0 || data.length <= threshold) {
+        return data.slice();
+      }
+      if (threshold === 2) {
+        return [data[0], data[data.length - 1]];
+      }
+
+      var sampled = [];
+      var bucketSize = (data.length - 2) / (threshold - 2);
+      var a = 0;
+      sampled.push(data[a]);
+
+      for (var i = 0; i < threshold - 2; i++) {
+        var avgRangeStart = Math.floor((i + 1) * bucketSize) + 1;
+        var avgRangeEnd = Math.floor((i + 2) * bucketSize) + 1;
+        if (avgRangeEnd > data.length) {
+          avgRangeEnd = data.length;
+        }
+
+        var avgX = 0;
+        var avgY = 0;
+        var avgRangeLength = avgRangeEnd - avgRangeStart;
+        for (var j = avgRangeStart; j < avgRangeEnd; j++) {
+          avgX += data[j][0];
+          avgY += data[j][1];
+        }
+        if (avgRangeLength > 0) {
+          avgX /= avgRangeLength;
+          avgY /= avgRangeLength;
+        } else {
+          avgX = data[a][0];
+          avgY = data[a][1];
+        }
+
+        var rangeOffs = Math.floor(i * bucketSize) + 1;
+        var rangeTo = Math.floor((i + 1) * bucketSize) + 1;
+        if (rangeTo >= data.length) {
+          rangeTo = data.length - 1;
+        }
+
+        var maxArea = -1;
+        var maxAreaPoint = data[rangeOffs];
+        var nextA = rangeOffs;
+
+        for (var k = rangeOffs; k < rangeTo; k++) {
+          var area = Math.abs(
+            (data[a][0] - avgX) * (data[k][1] - data[a][1]) -
+            (data[a][0] - data[k][0]) * (avgY - data[a][1])
+          ) * 0.5;
+          if (area > maxArea) {
+            maxArea = area;
+            maxAreaPoint = data[k];
+            nextA = k;
+          }
+        }
+
+        sampled.push(maxAreaPoint);
+        a = nextA;
+      }
+
+      sampled.push(data[data.length - 1]);
+      return sampled;
     };
 
     var getSelectedDataBounds = function() {
@@ -144,6 +210,7 @@ data = teams[0,3].map{|t| Team.get_historical_ratings(t.id)  }
         var rating = ratingData[key];
         if (key && rating) {
           var d = rating.data.filter(function(x) { return x[0] >= from && x[0] <= to; });
+          d = downsample(d, DOWNSAMPLE_THRESHOLD);
           data.push({
             data: d,
             label: rating.label,

--- a/test/unit/team_test.rb
+++ b/test/unit/team_test.rb
@@ -1,6 +1,48 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class TeamTest < Test::Unit::TestCase
+  def test_get_historical_ratings_returns_full_data_without_threshold
+    plucked_rows = [[Time.utc(2024, 1, 1), "12.5"], [Time.utc(2024, 1, 2), 13]]
+    historical_scope = Object.new
+    historical_scope.define_singleton_method(:order) do |field|
+      raise "unexpected order field" unless field == :measure_date
+      self
+    end
+    historical_scope.define_singleton_method(:pluck) do |*fields|
+      raise "unexpected pluck fields" unless fields == [:measure_date, :rating]
+      plucked_rows
+    end
+
+    HistoricalRating.stub(:where, historical_scope) do
+      assert_equal [[1704067200, 12.5], [1704153600, 13.0]], Team.get_historical_ratings(10)
+    end
+  end
+
+  def test_get_historical_ratings_downsamples_when_threshold_is_provided
+    data_rows = [[Time.utc(2024, 1, 1), 10.0], [Time.utc(2024, 1, 2), 11.0], [Time.utc(2024, 1, 3), 12.0]]
+    expected_data = data_rows.map { |date, rating| [date.to_i, rating.to_f] }
+    downsample_calls = []
+    historical_scope = Object.new
+    historical_scope.define_singleton_method(:order) do |field|
+      raise "unexpected order field" unless field == :measure_date
+      self
+    end
+    historical_scope.define_singleton_method(:pluck) do |*fields|
+      raise "unexpected pluck fields" unless fields == [:measure_date, :rating]
+      data_rows
+    end
+
+    HistoricalRating.stub(:where, historical_scope) do
+      LTTB.stub(:downsample, lambda { |data, threshold|
+        downsample_calls << [data, threshold]
+        [["downsampled"]]
+      }) do
+        assert_equal [["downsampled"]], Team.get_historical_ratings(10, 2)
+      end
+    end
+
+    assert_equal [[expected_data, 2]], downsample_calls
+  end
 
   # Replace this with your real tests.
   def test_truth


### PR DESCRIPTION
### Motivation
- Prevent premature LTTB downsampling of a team's full historical ratings so the selected time window is applied first and the graph reflects the chosen period accurately.
- Reduce client-side visual distortion caused by downsampling across the entire dataset when only a subset (period) is being displayed.

### Description
- Changed `Team.get_historical_ratings(team_id, threshold = nil)` to return the full time series by default and only call `LTTB.downsample` when an explicit `threshold` is provided (server-side change in `app/models/team.rb`).
- Implemented a client-side downsampling implementation and constant `DOWNSAMPLE_THRESHOLD = 300` inside `app/views/team/_team_rating_graph.html.erb` and applied it after filtering points by the selected period in `plotRatings` (so downsampling happens on already-filtered data).
- Kept backwards-compatible API by allowing an explicit threshold parameter to still trigger `LTTB.downsample` for callers that need immediate downsampling.
- Added tests in `test/unit/team_test.rb` to cover both branches: returning full data when `threshold` is omitted and calling `LTTB.downsample` when a `threshold` is provided.

### Testing
- Ran the unit tests with: `bin/rails test test/unit/team_test.rb test/unit/lttb_test.rb` and all tests passed (0 failures, 0 errors).
- The change was committed as: `Downsample team rating graph after period filtering` and includes modifications to `app/models/team.rb`, `app/views/team/_team_rating_graph.html.erb`, and `test/unit/team_test.rb`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23f3940c4833096af21618c1f973a)