### PR TITLE
Compute player-list footer totals on server-side datatables

### DIFF
--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -412,12 +412,68 @@ class ChampionshipController < ApplicationController
       recordsTotal: total_count,
       recordsFiltered: filtered_count,
       data: rows,
+      footer: player_list_footer(filtered),
     }
   end
 
   def relation_count(relation)
     sql = "SELECT COUNT(*) FROM (#{relation.except(:includes, :preload, :eager_load).unscope(:order).to_sql}) counted_rows"
     ActiveRecord::Base.connection.select_value(sql).to_i
+  end
+
+  def relation_totals(relation)
+    inner_sql = relation
+      .except(:includes, :preload, :eager_load)
+      .unscope(:order)
+      .select("minutes, goals, own_goals, penalties, appearances, played, sub, bench, yellows, reds, off_rating, def_rating")
+      .to_sql
+
+    sql = <<~SQL.squish
+      SELECT
+        COALESCE(SUM(minutes), 0) AS minutes,
+        COALESCE(SUM(goals), 0) AS goals,
+        COALESCE(SUM(own_goals), 0) AS own_goals,
+        COALESCE(SUM(penalties), 0) AS penalties,
+        COALESCE(SUM(appearances), 0) AS appearances,
+        COALESCE(SUM(played), 0) AS played,
+        COALESCE(SUM(sub), 0) AS sub,
+        COALESCE(SUM(bench), 0) AS bench,
+        COALESCE(SUM(yellows), 0) AS yellows,
+        COALESCE(SUM(reds), 0) AS reds,
+        COALESCE(SUM(off_rating), 0) AS off_rating,
+        COALESCE(SUM(def_rating), 0) AS def_rating
+      FROM (#{inner_sql}) totals_rows
+    SQL
+
+    ActiveRecord::Base.connection.select_one(sql) || {}
+  end
+
+  def player_list_footer(relation)
+    totals = relation_totals(relation)
+    minutes = totals["minutes"].to_f
+    goals = totals["goals"].to_f
+    rating = totals["off_rating"].to_f + totals["def_rating"].to_f
+
+    [
+      _("Total"),
+      "",
+      "",
+      totals["minutes"].to_i,
+      totals["goals"].to_i,
+      helpers.number_with_precision(goals / (minutes.nonzero? || 1) * 90, precision: 2),
+      helpers.number_with_precision(rating, precision: 2),
+      helpers.number_with_precision(rating / (minutes.nonzero? || 1) * 90, precision: 2),
+      helpers.number_with_precision(totals["off_rating"], precision: 2),
+      helpers.number_with_precision(totals["def_rating"], precision: 2),
+      totals["own_goals"].to_i,
+      totals["penalties"].to_i,
+      totals["appearances"].to_i,
+      totals["played"].to_i,
+      totals["sub"].to_i,
+      totals["bench"].to_i,
+      totals["yellows"].to_i,
+      totals["reds"].to_i,
+    ]
   end
 
   def player_list_order_sql(index)

--- a/app/controllers/championship_controller.rb
+++ b/app/controllers/championship_controller.rb
@@ -425,7 +425,6 @@ class ChampionshipController < ApplicationController
     inner_sql = relation
       .except(:includes, :preload, :eager_load)
       .unscope(:order)
-      .select("minutes, goals, own_goals, penalties, appearances, played, sub, bench, yellows, reds, off_rating, def_rating")
       .to_sql
 
     sql = <<~SQL.squish

--- a/app/views/shared/_player_stats_table.html.erb
+++ b/app/views/shared/_player_stats_table.html.erb
@@ -356,6 +356,21 @@ if (options.serverSide) {
     }
     d.minute_filter = parseInt($('#minute_filter').val() || 0, 10);
   };
+
+  options.footerCallback = function() {
+    var api = this.api();
+    var response = api.ajax.json();
+    var footer = response && response.footer;
+    if (!footer || !api.table().footer()) {
+      return;
+    }
+    api.columns().every(function(index) {
+      var cell = this.footer();
+      if (cell) {
+        cell.innerHTML = footer[index] == null ? '' : footer[index];
+      }
+    });
+  };
 }
 var text_targets_render = <%== Oj.dump(text_targets_render, mode: :compat) %>;
 options.columnDefs.push(...text_targets_render.map(function(x) {

--- a/test/functional/championship_controller_test.rb
+++ b/test/functional/championship_controller_test.rb
@@ -24,4 +24,41 @@ class ChampionshipControllerTest < Test::Unit::TestCase
       @controller.send(:player_list_order_clause, 0, "ASC")
     )
   end
+
+  def test_player_list_footer_formats_totals
+    totals = {
+      "minutes" => "180",
+      "goals" => "4",
+      "own_goals" => "1",
+      "penalties" => "2",
+      "appearances" => "7",
+      "played" => "6",
+      "sub" => "3",
+      "bench" => "1",
+      "yellows" => "2",
+      "reds" => "1",
+      "off_rating" => "5.5",
+      "def_rating" => "4.0",
+    }
+    @controller.define_singleton_method(:relation_totals) { |_relation| totals }
+
+    footer = @controller.send(:player_list_footer, Object.new)
+
+    assert_equal "Total", footer[0]
+    assert_equal 180, footer[3]
+    assert_equal 4, footer[4]
+    assert_equal "2.00", footer[5]
+    assert_equal "9.50", footer[6]
+    assert_equal "4.75", footer[7]
+    assert_equal "5.50", footer[8]
+    assert_equal "4.00", footer[9]
+    assert_equal 1, footer[10]
+    assert_equal 2, footer[11]
+    assert_equal 7, footer[12]
+    assert_equal 6, footer[13]
+    assert_equal 3, footer[14]
+    assert_equal 1, footer[15]
+    assert_equal 2, footer[16]
+    assert_equal 1, footer[17]
+  end
 end


### PR DESCRIPTION
### Motivation
- The players table footer showed zeros for server-side DataTables because totals were only computed client-side from passed-in rows.  
- We need efficient, accurate aggregates for filtered/ paginated championship player lists (minute filter, search, ordering) so the footer shows correct totals and per-90 derived metrics.

### Description
- Add `relation_totals` to compute aggregated sums in SQL over the filtered relation and `player_list_footer` to format totals and derived metrics (`goals_per_90`, `rating`, `rating_per_90`) for the response.  
- Return a `footer` array from `player_list_datatable_json` so the server supplies totals alongside `data`.  
- Update the shared player stats table JS to set a `footerCallback` when `serverSide` is enabled that fills `<tfoot>` cells from the server `response.footer` on each draw.  
- Add a functional test `test_player_list_footer_formats_totals` covering `player_list_footer` formatting and numeric conversions.

### Testing
- Ran the targeted functional test with `bin/rails test test/functional/championship_controller_test.rb`.  
- Test output: `3 runs, 18 assertions, 0 failures, 0 errors, 0 skips`, indicating the new footer formatting test passed.  
- No other automated tests were modified; changes are limited to `championship_controller`, the shared player table view JS, and the controller test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dac46ac88330b81546cfafcfacde)