### PR TITLE
Fix overtime red card player ratings

### DIFF
--- a/stats/src/main.rs
+++ b/stats/src/main.rs
@@ -398,10 +398,12 @@ fn compute_ratings(pool: &Pool<ConnectionManager<MysqlConnection>>) {
                         minutes: 0.0,
                     });
                 if v.pg.off == to && v.pg.red {
-                    player_game_rating.off -= 0.3 * (90.0 - v.pg.off as f32) / 90.0;
-                    player_game_rating.def -= 0.5 * (90.0 - v.pg.off as f32) / 90.0;
-                    player_rating.off -= 0.3 * (90.0 - v.pg.off as f32) / 90.0 * weight;
-                    player_rating.def -= 0.5 * (90.0 - v.pg.off as f32) / 90.0 * weight;
+                    let red_penalty_fraction =
+                        red_card_penalty_remaining_fraction(length, v.pg.off);
+                    player_game_rating.off -= 0.3 * red_penalty_fraction;
+                    player_game_rating.def -= 0.5 * red_penalty_fraction;
+                    player_rating.off -= 0.3 * red_penalty_fraction * weight;
+                    player_rating.def -= 0.5 * red_penalty_fraction * weight;
                     off_penalty += 0.3 / 90.0;
                     def_penalty += 0.5 / 90.0;
                 }
@@ -525,10 +527,12 @@ fn compute_ratings(pool: &Pool<ConnectionManager<MysqlConnection>>) {
                         minutes: 0.0,
                     });
                 if v.pg.off == to && v.pg.red {
-                    player_game_rating.off -= 0.3 * (90.0 - v.pg.off as f32) / 90.0;
-                    player_game_rating.def -= 0.5 * (90.0 - v.pg.off as f32) / 90.0;
-                    player_rating.off -= 0.3 * (90.0 - v.pg.off as f32) / 90.0 * weight;
-                    player_rating.def -= 0.5 * (90.0 - v.pg.off as f32) / 90.0 * weight;
+                    let red_penalty_fraction =
+                        red_card_penalty_remaining_fraction(length, v.pg.off);
+                    player_game_rating.off -= 0.3 * red_penalty_fraction;
+                    player_game_rating.def -= 0.5 * red_penalty_fraction;
+                    player_rating.off -= 0.3 * red_penalty_fraction * weight;
+                    player_rating.def -= 0.5 * red_penalty_fraction * weight;
                     off_penalty += 0.3 / 90.0;
                     def_penalty += 0.5 / 90.0;
                 }
@@ -789,9 +793,38 @@ fn goal_interval_filter(g: &Goal, from: i32, to: i32) -> bool {
     g.time >= from && (g.time < to || (g.time == 90 && to == 90) || (g.time == 45 && to == 45))
 }
 
+fn red_card_penalty_remaining_fraction(game_length: f32, player_off: i32) -> f32 {
+    ((game_length - player_off as f32) / 90.0).max(0.0)
+}
+
 fn get_rating(ratings: &mut HashMap<i32, VecDeque<HistoricalRating>>, date: NaiveDate, id: i32) {
     let r = ratings.get_mut(&id).expect("");
     while r.len() > 1 && date > r[1].measure_date {
         r.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::red_card_penalty_remaining_fraction;
+
+    #[test]
+    fn red_card_penalty_uses_regular_time_remaining_for_regular_game() {
+        assert_eq!(red_card_penalty_remaining_fraction(90.0, 60), 30.0 / 90.0);
+    }
+
+    #[test]
+    fn red_card_penalty_includes_overtime_remaining_when_game_has_overtime() {
+        assert_eq!(red_card_penalty_remaining_fraction(120.0, 60), 60.0 / 90.0);
+    }
+
+    #[test]
+    fn red_card_penalty_handles_cards_during_overtime() {
+        assert_eq!(red_card_penalty_remaining_fraction(120.0, 105), 15.0 / 90.0);
+    }
+
+    #[test]
+    fn red_card_penalty_never_rewards_late_cards() {
+        assert_eq!(red_card_penalty_remaining_fraction(90.0, 105), 0.0);
     }
 }

--- a/stats/src/main.rs
+++ b/stats/src/main.rs
@@ -398,12 +398,11 @@ fn compute_ratings(pool: &Pool<ConnectionManager<MysqlConnection>>) {
                         minutes: 0.0,
                     });
                 if v.pg.off == to && v.pg.red {
-                    let red_penalty_fraction =
-                        red_card_penalty_remaining_fraction(length, v.pg.off);
-                    player_game_rating.off -= 0.3 * red_penalty_fraction;
-                    player_game_rating.def -= 0.5 * red_penalty_fraction;
-                    player_rating.off -= 0.3 * red_penalty_fraction * weight;
-                    player_rating.def -= 0.5 * red_penalty_fraction * weight;
+                    let red_penalty_per90 = red_card_penalty_remaining_per90(length, v.pg.off);
+                    player_game_rating.off -= 0.3 * red_penalty_per90;
+                    player_game_rating.def -= 0.5 * red_penalty_per90;
+                    player_rating.off -= 0.3 * red_penalty_per90 * weight;
+                    player_rating.def -= 0.5 * red_penalty_per90 * weight;
                     off_penalty += 0.3 / 90.0;
                     def_penalty += 0.5 / 90.0;
                 }
@@ -527,12 +526,11 @@ fn compute_ratings(pool: &Pool<ConnectionManager<MysqlConnection>>) {
                         minutes: 0.0,
                     });
                 if v.pg.off == to && v.pg.red {
-                    let red_penalty_fraction =
-                        red_card_penalty_remaining_fraction(length, v.pg.off);
-                    player_game_rating.off -= 0.3 * red_penalty_fraction;
-                    player_game_rating.def -= 0.5 * red_penalty_fraction;
-                    player_rating.off -= 0.3 * red_penalty_fraction * weight;
-                    player_rating.def -= 0.5 * red_penalty_fraction * weight;
+                    let red_penalty_per90 = red_card_penalty_remaining_per90(length, v.pg.off);
+                    player_game_rating.off -= 0.3 * red_penalty_per90;
+                    player_game_rating.def -= 0.5 * red_penalty_per90;
+                    player_rating.off -= 0.3 * red_penalty_per90 * weight;
+                    player_rating.def -= 0.5 * red_penalty_per90 * weight;
                     off_penalty += 0.3 / 90.0;
                     def_penalty += 0.5 / 90.0;
                 }
@@ -793,7 +791,10 @@ fn goal_interval_filter(g: &Goal, from: i32, to: i32) -> bool {
     g.time >= from && (g.time < to || (g.time == 90 && to == 90) || (g.time == 45 && to == 45))
 }
 
-fn red_card_penalty_remaining_fraction(game_length: f32, player_off: i32) -> f32 {
+fn red_card_penalty_remaining_per90(game_length: f32, player_off: i32) -> f32 {
+    // Red-card penalties are calibrated per 90 minutes, not per match. An overtime
+    // match can therefore charge more than a normal match's full-game penalty when
+    // the player misses more than 90 minutes.
     ((game_length - player_off as f32) / 90.0).max(0.0)
 }
 
@@ -806,25 +807,25 @@ fn get_rating(ratings: &mut HashMap<i32, VecDeque<HistoricalRating>>, date: Naiv
 
 #[cfg(test)]
 mod tests {
-    use super::red_card_penalty_remaining_fraction;
+    use super::red_card_penalty_remaining_per90;
 
     #[test]
-    fn red_card_penalty_uses_regular_time_remaining_for_regular_game() {
-        assert_eq!(red_card_penalty_remaining_fraction(90.0, 60), 30.0 / 90.0);
+    fn red_card_penalty_uses_regular_time_remaining_per90() {
+        assert_eq!(red_card_penalty_remaining_per90(90.0, 60), 30.0 / 90.0);
     }
 
     #[test]
-    fn red_card_penalty_includes_overtime_remaining_when_game_has_overtime() {
-        assert_eq!(red_card_penalty_remaining_fraction(120.0, 60), 60.0 / 90.0);
+    fn red_card_penalty_includes_overtime_remaining_per90() {
+        assert_eq!(red_card_penalty_remaining_per90(120.0, 60), 60.0 / 90.0);
     }
 
     #[test]
-    fn red_card_penalty_handles_cards_during_overtime() {
-        assert_eq!(red_card_penalty_remaining_fraction(120.0, 105), 15.0 / 90.0);
+    fn red_card_penalty_handles_cards_during_overtime_per90() {
+        assert_eq!(red_card_penalty_remaining_per90(120.0, 105), 15.0 / 90.0);
     }
 
     #[test]
-    fn red_card_penalty_never_rewards_late_cards() {
-        assert_eq!(red_card_penalty_remaining_fraction(90.0, 105), 0.0);
+    fn red_card_penalty_per90_never_rewards_late_cards() {
+        assert_eq!(red_card_penalty_remaining_per90(90.0, 105), 0.0);
     }
 }


### PR DESCRIPTION
### Motivation
- Player rating red-card penalties were computed using only the remaining regular time, so players sent off before or during overtime were under-penalized.
- The rating pipeline already computes a match `length` (`90.0` or `120.0` when `home_aet` is present), so the red-card penalty should use that value to account for extra time.

### Description
- Add a helper `red_card_penalty_remaining_fraction(game_length: f32, player_off: i32) -> f32` that returns the remaining-minute fraction normalized to 90 minutes and clamps to zero for late cards.
- Replace the previous hard-coded `(90.0 - v.pg.off as f32) / 90.0` calculation with `red_card_penalty_remaining_fraction(length, v.pg.off)` in both the home and away player-rating loops.
- Reuse the existing `length` value (set to `120.0` when `home_aet` is present) so overtime minutes are counted correctly by the penalty.
- Add unit tests under `#[cfg(test)]` covering regular-time, overtime inclusion, a card during overtime, and clamping for late cards.

### Testing
- Ran `cd stats && cargo fmt && cargo test`, and the added unit tests passed: `4 passed; 0 failed`.
- Ran `cd stats && cargo check`, which completed successfully with no compiler errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e4c4ba9248330b395cac40b01fc17)